### PR TITLE
Sauce session name added, upgrade to intern 1.7 

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"dependencies": {
 	},
 	"devDependencies": {
-		"intern": "1.6",
+		"intern": "1.7",
 		"grunt": "~0.4.2",
 		"grunt-contrib-jshint": "~0.6.3",
 		"grunt-contrib-less": "~0.8.3",

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -17,11 +17,15 @@ define({
 
 		// Desktop.
 		// Not running on IE9 since Widget-attr test depends on domClass methods only available in IE10_
-		{ browserName: "internet explorer", version: "11", platform: "Windows 8.1", requireWindowFocus: "true", name : "deliteful"},
-		{ browserName: "internet explorer", version: "10", platform: "Windows 8", requireWindowFocus: "true", name : "deliteful"},
+		{ browserName: "internet explorer", version: "11", platform: "Windows 8.1", requireWindowFocus: "true",
+			name : "deliteful"},
+		{ browserName: "internet explorer", version: "10", platform: "Windows 8", requireWindowFocus: "true",
+			name : "deliteful"},
 		// { browserName: "internet explorer", version: "9", platform: "Windows 7" },
-		{ browserName: "firefox", version: "25", platform: [ /*"OS X 10.6", "Linux", */ "Windows 7" ], name : "deliteful"},
-		{ browserName: "chrome", version: "32", platform: [ /*"OS X 10.6", "Linux", */ "Windows 7" ], name : "deliteful"},
+		{ browserName: "firefox", version: "25", platform: [ /*"OS X 10.6", "Linux", */ "Windows 7" ],
+			name : "deliteful"},
+		{ browserName: "chrome", version: "32", platform: [ /*"OS X 10.6", "Linux", */ "Windows 7" ],
+			name : "deliteful"},
 		{ browserName: "safari", version: "6", platform: [ "OS X 10.8" ], name : "deliteful"},
 
 		// Mobile


### PR DESCRIPTION
Again it's a simple config change to update the sauce session name like (the many) other repo's running under the same sauce account have done. Makes it easier to identify what repo was being tested. 

Also updated intern to 1.7 (hide secure keys, better reporting etc)

Sorry, been a bit quiet recently but will get back to committing soon
