### PR TITLE
fix bower dependency for tests using dstore

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,6 +9,9 @@
 		"delite": ">=0.1.4-dev",
 		"requirejs-dplugins": ">=0.1.0-dev"
 	},
+	"devDependencies": {
+		"dstore" : ">=0.1.0-dev"
+	},
 	"ignore": [
 		".jshintrc",
 		".gitattributes",


### PR DESCRIPTION
bower doesn't include the dependency for dstore even though it's used in the repository
