### PR TITLE
List: changes corresponding to delite updates to KeyNav

### DIFF
--- a/list/List.js
+++ b/list/List.js
@@ -1070,10 +1070,15 @@ define([
 		 * @return {Element}
 		 * @private
 		 */
-		_getNext: function (child) {
+		_getNext: function (child, dir) {
+			if (child === this){
+				return dir > 0 ? this._getFirst() : this._getLast();
+			}
+
 			// Letter key navigation support.
 			var renderer = this.getEnclosingRenderer(child);
-			return renderer.nextElementSibling ? renderer.nextElementSibling.renderNode : this._getFirst();
+			return dir > 0 ? renderer.nextElementSibling ? renderer.nextElementSibling.renderNode : this._getFirst() :
+				renderer.previousElementSibling ? renderer.previousElementSibling.renderNode : this._getLast();
 		},
 
 		//////////// Extra methods for Keyboard navigation ///////////////////////////////////////


### PR DESCRIPTION
This makes _getNext() take dir parameter and work when the argument is the widget itself.

But instead, you should probably just remove _getNext(), _getFirst() and _getLast() altogether.

In any case, some change is needed after ibm-js/delite@c53fbf64d1060f327e5a2002e204096c5c897e91.
