### PR TITLE
New css loader plugin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,7 +40,7 @@ module.exports = function (grunt) {
 				dest: "build/<%= pkg.name %>.min.js"
 			}
 		},
-		
+
 		intern: {
 			local: {
 				options: {
@@ -71,7 +71,7 @@ module.exports = function (grunt) {
 				}
 			}
 		},
-		
+
 		"jsdoc-amddcl": {
 			docs: {
 				files: [
@@ -120,7 +120,7 @@ module.exports = function (grunt) {
 	// Aliases
 	grunt.registerTask("default", ["less"]);
 	grunt.registerTask("jsdoc", "jsdoc-amddcl");
-	
+
 	// Testing.
 	// always specify the target e.g. grunt test:remote, grunt test:remote
 	// then add on any other flags afterwards e.g. console, lcovhtml

--- a/Select.js
+++ b/Select.js
@@ -22,15 +22,15 @@ define([
 	 * store should not be done while the native dropdown of the select is open).
 	 * * The item rendering has the limitations of the `<option>` elements of the
 	 * native `<select>`, in particular it is text-only.
-	 * 
+	 *
 	 * TODO: improve doc.
-	 * 
+	 *
 	 * Remarks:
 	 * * The option items must be added, removed or updated exclusively using
 	 * the store API. Direct operations using the DOM API are not supported.
 	 * * The handling of the selected options of the underlying native `<select>`
 	 * must be done using the API inherited by deliteful/Select from delite/Selection.
-	 * 
+	 *
 	 * @example <caption>Using the default store</caption>
 	 * JS:
 	 * require("delite/register", "deliteful/Select", "requirejs-domready/domReady!"],
@@ -54,17 +54,17 @@ define([
 	 *   });
 	 * HTML:
 	 * <d-select selectionMode="multiple" id="select1"></d-select>
-	 * 
+	 *
 	 * @class module:deliteful/Select
 	 * @augments {module:delite/FormWidget}
 	 * @augments {module:delite/Store}
 	 */
 	return register("d-select", [HTMLElement, FormWidget, StoreMap, Selection],
 		/** @lends module:deliteful/Select# */ {
-		
+
 		// Note: the properties `store` and `query` are inherited from delite/Store, and
 		// the property `disabled` is inherited from delite/FormWidget.
-		
+
 		/**
 		 * The number of rows that should be visible at one time when the widget
 		 * is presented as a scrollable list box. Corresponds to the `size` attribute
@@ -73,7 +73,7 @@ define([
 		 * @default 0
 		 */
 		size: 0,
-		
+
 		/**
 		 * The name of the property of store items which contains the text
 		 * of Select's options.
@@ -81,7 +81,7 @@ define([
 		 * @default "text"
 		 */
 		textAttr: "text",
-		
+
 		/**
 		 * The name of the property of store items which contains the value
 		 * of Select's options.
@@ -89,7 +89,7 @@ define([
 		 * @default "value"
 		 */
 		valueAttr: "value",
-		
+
 		/**
 		 * The name of the property of store items which contains the disabled
 		 * value of Select's options. To disable a given option, the `disabled`
@@ -100,9 +100,9 @@ define([
 		 * @default "disabled"
 		 */
 		disabledAttr: "disabled",
-		
+
 		baseClass: "d-select",
-		
+
 		/**
 		 * The chosen selection mode.
 		 *
@@ -124,16 +124,16 @@ define([
 		 */
 		// The purpose of the above pseudo-property is to adjust the documentation
 		// of selectionMode as provided by delite/Selection.
-		  
+
 		template: template,
-		
+
 		startup: function () {
 			if (!this.store) { // If not specified by the user
 				this.store = new (Memory.createSubclass(Observable))({});
 			}
-			
+
 			this.focusNode = this.valueNode; // for delite/FormWidget's sake
-			
+
 			// To provide graphic feedback for focus, react to focus/blur events
 			// on the underlying native select. The CSS class is used instead
 			// of the focus pseudo-class because the browsers give the focus
@@ -144,7 +144,7 @@ define([
 			this.on("blur", function (evt) {
 				domClass.toggle(this, "d-select-focus", evt.type === "focus");
 			}.bind(this), this.valueNode);
-			
+
 			// Keep delite/Selection's selectedItem/selectedItems in sync after
 			// interactive selection of options.
 			this.on("change", function (event) {
@@ -183,23 +183,23 @@ define([
 						this.selectFromEvent(event, selectedOption.renderItem, selectedOption, true);
 					}
 				}
-				
+
 				// Update widget's value after interactive selection
 				this._set("value", this.valueNode.value);
 			}.bind(this), this.valueNode);
-			
+
 			// Thanks to the custom getter defined in deliteful/Select for widget's
 			// `value` property, there is no need to add code for keeping the
 			// property in sync after a form reset.
 		},
-		
+
 		hasSelectionModifier: function () {
 			// Override of the method from delite/Selection because the
 			// default implementation is inappropriate: the "change" event
 			// has no key modifier.
 			return this.selectionMode === "multiple";
 		},
-		
+
 		refreshRendering: function (props) {
 			if ("renderItems" in props) {
 				// Populate the select with the items retrieved from the store.
@@ -216,8 +216,8 @@ define([
 						option = this.ownerDocument.createElement("option");
 						option.renderItem = renderItem;
 						renderItem.visualItem = option;
-						
-						// According to http://www.w3.org/TR/html5/forms.html#the-option-element, we 
+
+						// According to http://www.w3.org/TR/html5/forms.html#the-option-element, we
 						// could use equivalently the label or the text IDL attribute of the option element.
 						// However, using the label attr. breaks the rendering in FF29/Win7!
 						// This is https://bugzilla.mozilla.org/show_bug.cgi?id=40545.
@@ -239,11 +239,11 @@ define([
 							// (<option disabled="false"> is a disabled option!)
 							option.setAttribute("disabled", "true");
 						}
-						
+
 						fragment.appendChild(option);
 					}
 					this.valueNode.appendChild(fragment);
-					
+
 					if (this.selectionMode === "single") {
 						// Since there is no native "change" event initially, initialize
 						// the delite/Selection's selectedItem property with the currently
@@ -252,31 +252,31 @@ define([
 							this.valueNode.options[this.valueNode.selectedIndex].renderItem;
 					} // else for the native multi-select: it does not have any
 					// option selected by default.
-					
+
 					// Initialize widget's value
 					this._set("value", this.valueNode.value);
 				}
 			}
 		},
-		
+
 		getIdentity: function (renderItem) {
 			// Override of delite/Selection's method
 			return renderItem.id;
 		},
-		
+
 		updateRenderers: function () {
 			// Override of delite/Selection's method
 			// Trigger rerendering from scratch:
 			this.notifyCurrentValue("renderItems");
 		},
-		
+
 		_setValueAttr: function (value) {
 			if (this.valueNode) {
 				this.valueNode.value = value;
 			}
 			this._set("value", value);
 		},
-		
+
 		_setSelectionModeAttr: dcl.superCall(function (sup) {
 			// Override of the setter from delite/Selection to forbid the value "none"
 			return function (value) {

--- a/SidePane.js
+++ b/SidePane.js
@@ -8,7 +8,7 @@ define([
 	"delite/DisplayContainer",
 	"dojo/Deferred",
 	"delite/theme!./SidePane/themes/{{theme}}/SidePane.css",
-	"requirejs-dplugins/has!bidi?delite/theme!./SidePane/themes/{{theme}}/SidePane.css"
+	"requirejs-dplugins/has!bidi?delite/theme!./SidePane/themes/{{theme}}/SidePane_rtl.css"
 ],
 	function (dcl, pointer, domClass, has, register, DisplayContainer, Deferred) {
 		function prefix(v) {

--- a/Slider.js
+++ b/Slider.js
@@ -530,7 +530,7 @@ define([
 					// selected value:
 					// relativePos > 0 => handleMin
 					// relativePos < 0 => focusNode
-					// relativePos = 0 => must be decided 
+					// relativePos = 0 => must be decided
 					var relativePos = Math.abs(selectedVal - currentVal[1]) - Math.abs(selectedVal - currentVal[0]);
 					if (relativePos === 0 && (e.target === this.focusNode || e.target === this.handleMin)) {
 						this._pointerCtx.target = document.elementFromPoint(e.clientX, e.clientY);
@@ -548,7 +548,7 @@ define([
 					}
 				}
 				if (e.target === this.focusNode || e.target === this.handleMin) {
-					// track offset between current and selected value 
+					// track offset between current and selected value
 					this._pointerCtx.offsetVal = selectedVal -
 						currentVal[(this.handleMin._isActive && (this._pointerCtx.target === this.focusNode)) ? 1 : 0];
 				}

--- a/StarRating.js
+++ b/StarRating.js
@@ -18,10 +18,10 @@ define([
 	 * A widget that displays a rating, usually with stars, and that allows setting a different rating value
 	 * by touching the stars.
 	 * Its custom element tag is `d-star-rating`.
-	 * 
+	 *
 	 * See the {@link https://github.com/ibm-js/deliteful/tree/master/docs/StarRating.md user documentation}
 	 * for more details.
-	 * 
+	 *
 	 * @class module:deliteful/StarRating
 	 * @augments delite/FormValueWidget
 	 */

--- a/Toaster.js
+++ b/Toaster.js
@@ -178,7 +178,7 @@ define(["dcl/dcl",
 			 *
 			 * @param {string|module:deliteful/ToasterMessage} message Either the content of the
 			 * message as a string or an instance of `deliteful/ToasterMessage`.
-			 * @param {Object} [props] A hash used to initialize a message instance (only relevant 
+			 * @param {Object} [props] A hash used to initialize a message instance (only relevant
 			 * when `message` passed is a string).
 			 *
 			 * @returns {module:deliteful/ToasterMessage} The message instance passed as a parameter

--- a/ViewStack.js
+++ b/ViewStack.js
@@ -41,7 +41,7 @@ define(["dcl/dcl",
 
 		/**
 		 * ViewStack container widget. Display one child at a time.
-		 * 
+		 *
 		 * The first child is displayed by default.
 		 * The methods 'show' is used to change the visible child.
 		 *

--- a/docs/ViewStack.md
+++ b/docs/ViewStack.md
@@ -18,10 +18,10 @@ Some of the transition types are described in the following picture:
 ![ViewStack Transitions](images/ViewStack.png)
 
 ##### Table of Contents
-[Element Instantiation](#instantiation)  
-[Element Configuration](#configuration)  
-[Element Styling](#styling)  
-[Enterprise Use](#enterprise)  
+[Element Instantiation](#instantiation)
+[Element Configuration](#configuration)
+[Element Styling](#styling)
+[Enterprise Use](#enterprise)
 
 <a name="instantiation"></a>
 ## Element Instantiation

--- a/list/List.js
+++ b/list/List.js
@@ -223,7 +223,7 @@ define([
 		 * @member {Element} module:deliteful/list/List#_previousFocusedChild
 		 * @private
 		 */
-		
+
 		/**
 		 * Flag set to a truthy value once the items have been loaded from the store
 		 * @member {boolean} module:deliteful/list/List#_dataLoaded
@@ -935,7 +935,7 @@ define([
 		//////////// delite/Scrollable extension ///////////////////////////////////////
 
 		/**
-		 * Returns the distance between the top of a node and 
+		 * Returns the distance between the top of a node and
 		 * the top of the scrolling container.
 		 * @param {Node} node the node
 		 * @protected


### PR DESCRIPTION
Convert `_css.js` files to plain CSS.
Also update all the dependencies ending with `*_css` to `*.css`.
