### PR TITLE
Fixes #247 ToasterMessage: fix dismiss by touching close button on mobile

### DIFF
--- a/ToasterMessage.js
+++ b/ToasterMessage.js
@@ -480,9 +480,9 @@ define(["dcl/dcl",
 
 			// setting up click listener for dismiss button
 			if (this._dismissButton !== null) {
-				this.own(on(this._dismissButton, "click", function () {
+				this.on("pointerdown", function (evt) {
 					this.dismiss();
-				}.bind(this)));
+				}.bind(this), this._dismissButton);
 			}
 		}
 	});


### PR DESCRIPTION
Fix for https://github.com/ibm-js/deliteful/issues/247 
