### PR TITLE
Adapt deliteful to recent changes in delite (removal of underscore prefix for protected members)

### DIFF
--- a/ViewStack.js
+++ b/ViewStack.js
@@ -97,7 +97,7 @@ define(["dcl/dcl",
 
 			_setSelectedChildIdAttr: function (child) {
 				if (this.ownerDocument.getElementById(child)) {
-					if (this._started) {
+					if (this.started) {
 						this.show(child);
 					} else {
 						this._pendingChild = child;

--- a/list/List.js
+++ b/list/List.js
@@ -1013,7 +1013,7 @@ define([
 		 * Handle keydown events
 		 * @private
 		 */
-		_onContainerKeydown: dcl.before(function (evt) {
+		_keynavKeyDownHandler: dcl.before(function (evt) {
 			if (!evt.defaultPrevented) {
 				if ((evt.keyCode === keys.SPACE && !this._searchTimer)) {
 					this._spaceKeydownHandler(evt);
@@ -1065,7 +1065,7 @@ define([
 		_getFirst: function () {
 			var first = this.scrollableNode.querySelector("." + this._cssClasses.cell);
 			if (first && this.isAriaListbox && this._isCategoryRenderer(this.getEnclosingRenderer(first))) {
-				first = this._getNext(first, 1);
+				first = this.getNext(first, 1);
 			}
 			return first;
 		},
@@ -1080,16 +1080,14 @@ define([
 			var cells = this.scrollableNode.querySelectorAll("." + this._cssClasses.cell);
 			var last = cells.length ? cells.item(cells.length - 1) : null;
 			if (last && this.isAriaListbox && this._isCategoryRenderer(this.getEnclosingRenderer(last))) {
-				last = this._getNext(last, -1);
+				last = this.getNext(last, -1);
 			}
 			return last;
 		},
 
 		// Simple arrow key support.
-		/**
-		 * @private
-		 */
-		_onDownArrow: function () {
+
+		onDownArrow: function () {
 			if (this.focusedChild.hasAttribute("navindex")) {
 				return;
 			}
@@ -1100,10 +1098,7 @@ define([
 			this.focusChild(next ? next.renderNode : this._getFirst());
 		},
 
-		/**
-		 * @private
-		 */
-		_onUpArrow: function () {
+		onUpArrow: function () {
 			if (this.focusedChild.hasAttribute("navindex")) {
 				return;
 			}
@@ -1114,12 +1109,7 @@ define([
 			this.focusChild(next ? next.renderNode : this._getLast());
 		},
 
-		/**
-		 * @param {Element} child
-		 * @return {Element}
-		 * @private
-		 */
-		_getNext: function (child, dir) {
+		getNext: function (child, dir) {
 			if (child === this) {
 				return dir > 0 ? this._getFirst() : this._getLast();
 			}
@@ -1164,11 +1154,11 @@ define([
 					// We are in Actionable mode
 					evt.preventDefault();
 					var renderer = this._getFocusedRenderer();
-					var next = renderer[evt.shiftKey ? "_getPrev" : "_getNext"](this.focusedChild);
+					var next = renderer[evt.shiftKey ? "getPrev" : "getNext"](this.focusedChild);
 					while (!next) {
 						renderer = renderer[evt.shiftKey ? "previousElementSibling" : "nextElementSibling"]
 							|| this[evt.shiftKey ? "_getLast" : "_getFirst"]().parentNode;
-						next = renderer[evt.shiftKey ? "_getLast" : "_getFirst"]();
+						next = renderer[evt.shiftKey ? "getLast" : "getFirst"]();
 					}
 					this.focusChild(next);
 				}

--- a/list/Renderer.js
+++ b/list/Renderer.js
@@ -61,7 +61,7 @@ define([
 		 * @returns {Element}
 		 * @protected
 		 */
-		_getFirst: function () {
+		getFirst: function () {
 			if (this._focusableChildren && this._focusableChildren.length) {
 				return this._focusableChildren[0];
 			} else {
@@ -74,7 +74,7 @@ define([
 		 * @returns {Element}
 		 * @protected
 		 */
-		_getLast: function () {
+		getLast: function () {
 			if (this._focusableChildren && this._focusableChildren.length) {
 				return this._focusableChildren[this._focusableChildren.length - 1];
 			} else {
@@ -88,8 +88,8 @@ define([
 		 * @returns {Element}
 		 * @protected
 		 */
-		_getNext: function (child) {
-			return this._getNextFocusableChild(child, 1);
+		getNext: function (child) {
+			return this.getNextFocusableChild(child, 1);
 		},
 
 		/**
@@ -98,8 +98,8 @@ define([
 		 * @returns {Element}
 		 * @protected
 		 */
-		_getPrev: function (child) {
-			return this._getNextFocusableChild(child, -1);
+		getPrev: function (child) {
+			return this.getNextFocusableChild(child, -1);
 		},
 
 		/**
@@ -147,7 +147,7 @@ define([
 		 * @returns {Element} The next focusable child if there is one.
 		 * @protected
 		 */
-		_getNextFocusableChild: function (fromChild, dir) {
+		getNextFocusableChild: function (fromChild, dir) {
 			if (this._focusableChildren && fromChild !== this) {
 				// retrieve the position of the from node
 				var fromChildIndex = fromChild ? this._focusableChildren.indexOf(fromChild) : -1;


### PR DESCRIPTION
This PR is to start collecting adaptations after delite's recent changes:
- Removal of underscore prefix for protected properties (https://github.com/ibm-js/delite/commit/672db9f9ecfb90870fd7914cab2f7f8f835db49f )
- Update: removed this commit since handled in #261. "widgets should leverage attachedCallback() and not startup()" (https://github.com/ibm-js/delite/commit/01a0439d472a5a9c2f2fb69b6a307b0f2a0cf358)

Remarks:
- This PR is NOT to be merged now (because deliteful still depends on the old delite release; we first need a new delite release).
- With the current PR, all deliteful unit tests pass except PageableList's. This still needs to be investigated and fixed.
