### PR TITLE
Select: take into account data store's idProperty. Fixes #255

### DIFF
--- a/Select.js
+++ b/Select.js
@@ -259,7 +259,7 @@ define([
 		
 		getIdentity: function (renderItem) {
 			// Override of delite/Selection's method
-			return renderItem.id;
+			return renderItem[this.store.idProperty];
 		},
 		
 		updateRenderers: function () {


### PR DESCRIPTION
deliteful/Select should not use directly item's id property, but the property defined by data store's idProperty. 
See #255.
