### PR TITLE
Select: ensure the API of delite/Selection is always called for data items, not for StoreMap's render items; fix of getIdentity() to take into account store's idProperty. Refs #255

### DIFF
--- a/Select.js
+++ b/Select.js
@@ -170,16 +170,16 @@ define([
 				// which are no longer selected in the native select.
 				for (i = 0; i < nSelectedItems; i++) {
 					selectedItem = selectedItems[i];
-					if (selectedOptions.indexOf(selectedItem.visualItem) === -1) {
-						this.selectFromEvent(event, selectedItem, selectedItem.visualItem, true);
+					if (selectedOptions.indexOf(selectedItem._visualItem) === -1) {
+						this.selectFromEvent(event, selectedItem, selectedItem._visualItem, true);
 					}
 				}
 				// Step 2. Search options newly selected in the native select which are not
 				// present in the current selection (widget.selectedItems).
 				for (i = 0; i < nSelectedOptions; i++) {
 					selectedOption = selectedOptions[i];
-					if (selectedItems.indexOf(selectedOption.renderItem) === - 1) {
-						this.selectFromEvent(event, selectedOption.renderItem, selectedOption, true);
+					if (selectedItems.indexOf(selectedOption._dataItem) === - 1) {
+						this.selectFromEvent(event, selectedOption._dataItem, selectedOption, true);
 					}
 				}
 				
@@ -213,8 +213,11 @@ define([
 					for (var i = 0; i < n; i++) {
 						renderItem = renderItems[i];
 						option = this.ownerDocument.createElement("option");
-						option.renderItem = renderItem;
-						renderItem.visualItem = option;
+						// to allow retrieving the data item from the option element
+						option._dataItem = renderItem.__item;
+						// to allow retrieving the option element from widget's selectedItems
+						// (which are data items, not render items).
+						option._dataItem._visualItem = option;
 						
 						// According to http://www.w3.org/TR/html5/forms.html#the-option-element, we 
 						// could use equivalently the label or the text IDL attribute of the option element.
@@ -229,7 +232,12 @@ define([
 						if (renderItem.value !== undefined) { // optional
 							option.setAttribute("value", renderItem.value);
 						}
-						if (this.isSelected(renderItem)) { // delite/Selection's API
+						// The selection API (delite/Selection) needs to be called consistently
+						// for data items, not for render items.
+						// renderItem.__item is the data item instance for which
+						// StoreMap.itemToRenderItem() has created the render item.
+						// For now there is no public API for accessing it.
+						if (this.isSelected(renderItem.__item)) { // delite/Selection's API
 							option.setAttribute("selected", "true");
 						}
 						if (renderItem.disabled !== undefined &&
@@ -248,7 +256,7 @@ define([
 						// the delite/Selection's selectedItem property with the currently
 						// selected option of the native select.
 						this.selectedItem =
-							this.valueNode.options[this.valueNode.selectedIndex].renderItem;
+							this.valueNode.options[this.valueNode.selectedIndex]._dataItem;
 					} // else for the native multi-select: it does not have any
 					// option selected by default.
 					
@@ -258,9 +266,9 @@ define([
 			}
 		},
 		
-		getIdentity: function (renderItem) {
+		getIdentity: function (dataItem) {
 			// Override of delite/Selection's method
-			return renderItem.id;
+			this.store.getIdentity(dataItem);
 		},
 		
 		updateRenderers: function () {


### PR DESCRIPTION
This takes profit from the recent https://github.com/cjolif/delite/commit/247229c283c69606c08aacdaba2470e475bf6e26. Hence, it MUST not be merged before this commit will be included in a new release of delite used by deliteful.
