### PR TITLE
removed all dojo/on references fixes #363

### DIFF
--- a/Slider.js
+++ b/Slider.js
@@ -4,14 +4,13 @@ define([
 	"dojo/dom-construct",
 	"dojo/dom-style",
 	"dojo/keys",
-	"dojo/on",
 	"dpointer/events",
 	"delite/register",
 	"delite/FormValueWidget",
 	"delite/CssState",
 	"delite/handlebars!./Slider/Slider.html",
 	"delite/theme!./Slider/themes/{{theme}}/Slider.css"
-], function (domClass, domConstruct, domStyle, keys, on, dpointer, register, FormValueWidget, CssState, template) {
+], function (domClass, domConstruct, domStyle, keys, dpointer, register, FormValueWidget, CssState, template) {
 	/**
 	 * @private
 	 */
@@ -334,15 +333,13 @@ define([
 					offsetVal: 0, // Offset value when use points and drag a handle
 					containerBox: null // to avoid recalculations when moving the slider with a pointer
 				};
-				this.own(
-					on(this, "pointerdown", this.pointerDownHandler.bind(this)),
-					on(this, "pointermove", this.pointerMoveHandler.bind(this)),
-					on(this, "lostpointercapture", this.lostCaptureHandler.bind(this)),
-					on(this, "keydown", this.keyDownHandler.bind(this)),
-					on(this, "keyup", this.keyUpHandler.bind(this)),
-					on(this.focusNode, "focus", this.focusHandler.bind(this)),
-					on(this.handleMin, "focus", this.focusHandler.bind(this))
-				);
+				this.on("pointerdown", this.pointerDownHandler.bind(this));
+				this.on("pointermove", this.pointerMoveHandler.bind(this));
+				this.on("lostpointercapture", this.lostCaptureHandler.bind(this));
+				this.on("keydown", this.keyDownHandler.bind(this));
+				this.on("keyup", this.keyUpHandler.bind(this));
+				this.on("focus", this.focusHandler.bind(this));
+				this.on("focus", this.focusHandler.bind(this));
 
 				// ensure CSS is applied
 				this.notifyCurrentValue("vertical");
@@ -364,13 +361,13 @@ define([
 				// if the form is reset, then notify the widget to reposition the handles
 				if (this.valueNode.form) {
 					var self = this;
-					this.own(on(this.valueNode.form, "reset", function () {
+					this.on("reset", function () {
 						self.defer(function () {
 							if (this.value !== this.valueNode.value) {
 								this.value = this.valueNode.value;
 							}
 						});
-					}));
+					}, this.valueNode.form);
 				}
 				// Chrome: avoids text selection of elements when mouse is dragged outside of the Slider.
 				this.onmousedown = function (e) {

--- a/ToasterMessage.js
+++ b/ToasterMessage.js
@@ -4,10 +4,9 @@ define(["dcl/dcl",
 	"delite/register",
 	"dojo/Deferred",
 	"dojo/dom-class",
-	"dojo/on",
 	"dpointer/events",
 	"delite/handlebars!./Toaster/ToasterMessage.html"
-], function (dcl, Widget, register, Deferred, domClass, on, pointer, template) {
+], function (dcl, Widget, register, Deferred, domClass, pointer, template) {
 
 	// TODO: this could be abstracted in a separate class, so that it can be used by other widgets
 	// such as the toggle/switch.
@@ -266,11 +265,14 @@ define(["dcl/dcl",
 		var events = [animationendEvent, transitionendEvent];
 		events.forEach(function (event) {
 			if (event) { // if event is supported
-				on.once(element, event, (function (el, ev) {
+				var tmp = {};
+				var listener = (function (el, ev, d) {
 					return function () {
 						callback(el, ev);
+						d.handler.remove();
 					};
-				})(element, event), false);
+				})(element, event, tmp);
+				tmp.handler = element.on(event, listener);
 			} else {
 				callback(element, event);
 			}

--- a/ViewStack.js
+++ b/ViewStack.js
@@ -1,7 +1,6 @@
 /** @module deliteful/ViewStack */
 define(["dcl/dcl",
 	"decor/sniff",
-	"dojo/on",
 	"dojo/Deferred",
 	"dojo/dom-class",
 	"delite/register",
@@ -10,7 +9,7 @@ define(["dcl/dcl",
 	"delite/theme!./ViewStack/themes/{{theme}}/ViewStack.css",
 	"requirejs-dplugins/css!./ViewStack/transitions/slide.css",
 	"requirejs-dplugins/css!./ViewStack/transitions/reveal.css"],
-	function (dcl, has, on, Deferred, domClass, register, Widget, DisplayContainer) {
+	function (dcl, has, Deferred, domClass, register, Widget, DisplayContainer) {
 		function setVisibility(node, val) {
 			if (node) {
 				if (val) {

--- a/list/List.js
+++ b/list/List.js
@@ -2,7 +2,6 @@
 define([
 	"dcl/dcl",
 	"delite/register",
-	"dojo/on",
 	"dojo/_base/lang",
 	"dojo/when",
 	"dojo/dom-class",
@@ -17,7 +16,7 @@ define([
 	"./_LoadingPanel",
 	"delite/theme!./List/themes/{{theme}}/List.css",
 	"requirejs-dplugins/has!dojo-bidi?delite/theme!./List/themes/{{theme}}/List_rtl.css"
-], function (dcl, register, on, lang, when, domClass, keys, CustomElement,
+], function (dcl, register, lang, when, domClass, keys, CustomElement,
 		Selection, KeyNav, StoreMap, Scrollable, ItemRenderer, CategoryRenderer, LoadingPanel) {
 
 	/**
@@ -233,11 +232,6 @@ define([
 		render: function () {
 			// Initialize the widget node and set the container and scrollable node.
 			this.scrollableNode = this.ownerDocument.createElement("div");
-			// Firefox focus the scrollable node when clicking it or tabing: in this case, the list
-			// widget needs to be focused instead.
-			this.own(on(this.scrollableNode, "focus", function () {
-				this.focus();
-			}.bind(this)));
 			this.scrollableNode.className = "d-list-container";
 			this.appendChild(this.scrollableNode);
 			// Aria attributes

--- a/list/PageableList.js
+++ b/list/PageableList.js
@@ -2,7 +2,6 @@
 define([
 	"dcl/dcl",
 	"delite/register",
-	"dojo/on",
 	"dojo/string",
 	"dojo/when",
 	"dojo/Deferred",
@@ -12,7 +11,7 @@ define([
 	"./Renderer",
 	"delite/handlebars!./List/_PageLoaderRenderer.html",
 	"requirejs-dplugins/i18n!./List/nls/Pageable"
-], function (dcl, register, on, string, when, Deferred, domClass, has,
+], function (dcl, register, string, when, Deferred, domClass, has,
 		List, Renderer, template, messages) {
 
 	/*
@@ -221,7 +220,7 @@ define([
 				this._autoPagingHandle = null;
 			}
 			if (value) {
-				this._autoPagingHandle = this.own(on(this.scrollableNode, "scroll", this._scrollHandler.bind(this)))[0];
+				this._autoPagingHandle = this.on("scroll", this._scrollHandler.bind(this), this.scrollableNode);
 			}
 		},
 

--- a/samples/list/listBox-multipleSelection-markBefore.html
+++ b/samples/list/listBox-multipleSelection-markBefore.html
@@ -19,13 +19,12 @@
 	<script type="text/javascript">
 		require([
 			"delite/register",
-			"dojo/on",
 			"dstore/Memory",
 			"dstore/Trackable",
 			"deliteful/list/List",
 			"delite/theme!delite/themes/{{theme}}/global.css", // page level CSS
 			"requirejs-domready/domReady!"
-		], function (register, on, Memory, Trackable) {
+		], function (register, Memory, Trackable) {
 			var Store = Memory.createSubclass([Trackable], {});
 			var console = document.createElement("p");
 			console.innerHTML = "Click to select an item.";

--- a/samples/list/listBox-singleSelection-markAfter.html
+++ b/samples/list/listBox-singleSelection-markAfter.html
@@ -19,12 +19,11 @@
 	<script type="text/javascript">
 		require([
 		    "delite/register",
-		    "dojo/on",
 			"dstore/Memory",
 			"dstore/Trackable",
 			"deliteful/list/List",
 			"delite/theme!delite/themes/{{theme}}/global.css"	// page level CSS
-		], function (register, on, Memory, Trackable, List) {
+		], function (register, Memory, Trackable, List) {
 			var Store = Memory.createSubclass([Trackable], {});
 			var console = document.createElement("div");
 			console.innerHTML = "Click to select an item.";


### PR DESCRIPTION
I'm removed all dojo/on references in the files mentionned in #363 
- Note that in [List.js](https://github.com/ibm-js/deliteful/pull/384/files#diff-6de834fe8c8b92d25c133e8b8b06d4b9L236), I didn't convert the dojo/on() to a widget.on() but rather removed it altogether after discussing it with @sbrunot. The reason exposed by the comment above it no longer stand. 
- I didn't find an easy way to convert the [on.once()](https://github.com/ibm-js/deliteful/pull/384/files#diff-46c2d2785e39b8aece88be7198e1dafeL269). I'm not very satisfied with the current workaround, feel free to suggest a better way.
