### PR TITLE
fixed issue with labels attached through for on ios fixes #361

### DIFF
--- a/Checkbox/themes/Checkbox_ios.css
+++ b/Checkbox/themes/Checkbox_ios.css
@@ -1,3 +1,0 @@
-label[for] {
-  cursor: pointer;
-}

--- a/Checkbox/themes/Checkbox_ios.less
+++ b/Checkbox/themes/Checkbox_ios.less
@@ -1,3 +1,0 @@
-label[for] {
-	cursor: pointer;
-}

--- a/Checkbox/themes/Checkbox_template.less
+++ b/Checkbox/themes/Checkbox_template.less
@@ -48,3 +48,9 @@
 		cursor: not-allowed;
 	}
 }
+
+label[for] {
+	// fixes a ios bug that makes it so that the handler set on document, 
+	// listening for clicks on label, is never called.
+	cursor: pointer;
+}

--- a/Checkbox/themes/bootstrap/Checkbox.css
+++ b/Checkbox/themes/bootstrap/Checkbox.css
@@ -60,3 +60,6 @@ fieldset[disabled] .d-checkbox {
 fieldset[disabled] .d-checkbox > input[type=checkbox] {
   cursor: not-allowed;
 }
+label[for] {
+  cursor: pointer;
+}

--- a/Checkbox/themes/holodark/Checkbox.css
+++ b/Checkbox/themes/holodark/Checkbox.css
@@ -63,3 +63,6 @@ fieldset[disabled] .d-checkbox {
 fieldset[disabled] .d-checkbox > input[type=checkbox] {
   cursor: not-allowed;
 }
+label[for] {
+  cursor: pointer;
+}

--- a/Checkbox/themes/ios/Checkbox.css
+++ b/Checkbox/themes/ios/Checkbox.css
@@ -69,3 +69,6 @@ fieldset[disabled] .d-checkbox {
 fieldset[disabled] .d-checkbox > input[type=checkbox] {
   cursor: not-allowed;
 }
+label[for] {
+  cursor: pointer;
+}


### PR DESCRIPTION
1. created `Checkbox/themes/Checkbox_iosfix.less`
2. changed Gruntfile.js to automatically compile all `*/themes/*.less` except for those that look like 
   `*_template.less`, `*_template_*.less` or `variables.less`.
3. used decor/sniff to load `Checkbox/themes/Checkbox_ios.css` when ios is detected.
