### PR TITLE
fixed ugly outline around Switch fixes #299

### DIFF
--- a/Switch/themes/Switch_template.less
+++ b/Switch/themes/Switch_template.less
@@ -4,10 +4,11 @@
 	font-size: 0.9em;
 	position:relative;
 	overflow:hidden;
-	box-shadow: 0 0px 3px black;
 	margin: 3px;
 	white-space:nowrap;
+	.d-switch-styles();
 	&.d-focused {
+		outline:0;
 		.d-switch-focused-styles();
 	}
 }
@@ -83,7 +84,6 @@
 	margin: 0px;
 	&:checked + .-d-switch-push {
 		margin-left: -@d-switch-knob-w;
-//		.d-switch-width();
 	}
 }
 

--- a/Switch/themes/bootstrap/Switch.css
+++ b/Switch/themes/bootstrap/Switch.css
@@ -3,14 +3,16 @@
   font-size: 0.9em;
   position: relative;
   overflow: hidden;
-  box-shadow: 0 0px 3px black;
   margin: 3px;
   white-space: nowrap;
+  border: 1px solid #c8c8c8;
 }
 .d-switch.d-focused {
-  outline: thin dotted;
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;
+  outline: 0;
+  -webkit-box-shadow: 0 0 8px rgba(102, 175, 233, 0.6);
+  -moz-box-shadow: 0 0 8px rgba(102, 175, 233, 0.6);
+  box-shadow: 0 0 8px rgba(102, 175, 233, 0.6);
+  border-color: #66afe9;
 }
 .-d-switch-inner {
   position: absolute;
@@ -49,7 +51,7 @@
   left: 50%;
   margin-left: -15px;
   z-index: 5;
-  box-shadow: 0 1px 6px black;
+  box-shadow: 0 1px 6px #a2a2a2;
   background: #eeeeee;
 }
 .-d-switch-knobglass {

--- a/Switch/themes/bootstrap/Switch.less
+++ b/Switch/themes/bootstrap/Switch.less
@@ -13,13 +13,15 @@
 	color: @gray;
 }
 .d-switch-knob-styles() {
-	box-shadow: 0 1px 6px black;
+	box-shadow: 0 1px 6px darken(@gray-lighter, 30%);
 	background: @gray-lighter;
 }
-.d-switch-focused-styles () {
-	outline: thin dotted;
-	outline: 5px auto -webkit-focus-ring-color;
-	outline-offset: -2px;
+.d-switch-styles() {
+	border: 1px solid darken(@gray-lighter, 15%);
+}
+.d-switch-focused-styles() {
+	.box-shadow(0 0 8px rgba(102,175,233,.6));
+	border-color: rgba(102,175,233,1);
 }
 
 @import "../Switch_template.less";

--- a/Switch/themes/holodark/Switch.css
+++ b/Switch/themes/holodark/Switch.css
@@ -3,14 +3,15 @@
   font-size: 0.9em;
   position: relative;
   overflow: hidden;
-  box-shadow: 0 0px 3px black;
   margin: 3px;
   white-space: nowrap;
 }
 .d-switch.d-focused {
-  outline: thin dotted;
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;
+  outline: 0;
+  -webkit-box-shadow: 0 0 8px rgba(102, 175, 233, 0.6);
+  -moz-box-shadow: 0 0 8px rgba(102, 175, 233, 0.6);
+  box-shadow: 0 0 8px rgba(102, 175, 233, 0.6);
+  border-color: #66afe9;
 }
 .-d-switch-inner {
   position: absolute;

--- a/Switch/themes/holodark/Switch.less
+++ b/Switch/themes/holodark/Switch.less
@@ -16,10 +16,10 @@
 	background-color: @holo-switch-knob-color;
 	background-image: none;
 }
-.d-switch-focused-styles () {
-	outline: thin dotted;
-	outline: 5px auto -webkit-focus-ring-color;
-	outline-offset: -2px;
+.d-switch-styles() {}
+.d-switch-focused-styles() {
+	.box-shadow(0 0 8px rgba(102,175,233,.6));
+	border-color: rgba(102,175,233,1);
 }
 
 @d-switch-rounded-radius: 0px;

--- a/Switch/themes/ios/Switch.css
+++ b/Switch/themes/ios/Switch.css
@@ -3,14 +3,16 @@
   font-size: 0.9em;
   position: relative;
   overflow: hidden;
-  box-shadow: 0 0px 3px black;
   margin: 3px;
   white-space: nowrap;
+  border: 1px solid #aeaeae;
 }
 .d-switch.d-focused {
-  outline: thin dotted;
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;
+  outline: 0;
+  -webkit-box-shadow: 0 0 8px rgba(102, 175, 233, 0.6);
+  -moz-box-shadow: 0 0 8px rgba(102, 175, 233, 0.6);
+  box-shadow: 0 0 8px rgba(102, 175, 233, 0.6);
+  border-color: #66afe9;
 }
 .-d-switch-inner {
   position: absolute;
@@ -53,7 +55,7 @@
   left: 50%;
   margin-left: -15px;
   z-index: 5;
-  box-shadow: 0 1px 6px black;
+  box-shadow: 0 1px 6px #909090;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#cccccc), to(#fafafa));
   background-image: linear-gradient(to bottom, #cccccc 0%, #fafafa 100%);
 }

--- a/Switch/themes/ios/Switch.less
+++ b/Switch/themes/ios/Switch.less
@@ -12,13 +12,15 @@
 	font-weight: bold;
 }
 .d-switch-knob-styles() {
-	box-shadow: 0 1px 6px black;
+	box-shadow: 0 1px 6px darken(#eee, 37%);
 	.background-image-linear-gradient-top-bottom(#cccccc, #fafafa);
 }
-.d-switch-focused-styles () {
-	outline: thin dotted;
-	outline: 5px auto -webkit-focus-ring-color;
-	outline-offset: -2px;
+.d-switch-styles() {
+	border: 1px solid darken(#eee, 25%);
+}
+.d-switch-focused-styles() {
+	.box-shadow(0 0 8px rgba(102,175,233,.6));
+	border-color: rgba(102,175,233,1);
 }
 
 @import "../Switch_template.less";


### PR DESCRIPTION
Here is how it looks now. 

![image](https://cloud.githubusercontent.com/assets/2982512/5281307/1e9d36d8-7afc-11e4-9760-28267c4d6e2a.png)
![image](https://cloud.githubusercontent.com/assets/2982512/5281318/38698242-7afc-11e4-8f6e-116be64d4581.png)
![image](https://cloud.githubusercontent.com/assets/2982512/5281356/a4e3763a-7afc-11e4-8785-2518cb9271b6.png)

I have mentioned other widgets with malformed outlines in #299 but didn't change anything besides Switch.
