### PR TITLE
renabled testing for ie10

### DIFF
--- a/tests/unit/list/PageableList.js
+++ b/tests/unit/list/PageableList.js
@@ -12,13 +12,6 @@ define([
 
 	var Store = Memory.createSubclass([Trackable], {});
 
-	// PageableList is currently not supported on IE10
-	// see https://github.com/ibm-js/deliteful/issues/280
-	if (has("ie") > 9 && has("ie") < 11) {
-		console.log("Skipping PageableList tests on IE10 (see https://github.com/ibm-js/deliteful/issues/280)");
-		return;
-	}
-
 	/////////////////////////////////
 	// List base tests
 	/////////////////////////////////


### PR DESCRIPTION
I couldn't find out precisely what version of IE10 saucelab is using but I've tested this on saucelab and the original problem seem to have disappeared. 
