### PR TITLE
Updated the deliteful code to use skip() to skip a testcase instead of c...

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,35 +48,35 @@ module.exports = function (grunt) {
 				options: {
 					runType: "runner",
 					config: "tests/intern.local",
-					reporters: ["runner"]
+					reporters: [] // pass :runner to avoid logging STARTED & SKIPPED
 				}
 			},
 			"local.android": {
 				options: {
 					runType: "runner",
 					config: "tests/intern.local.android",
-					reporters: ["runner"]
+					reporters: [] // pass :runner to avoid logging STARTED & SKIPPED
 				}
 			},
 			"local.ios": {
 				options: {
 					runType: "runner",
 					config: "tests/intern.local.ios",
-					reporters: ["runner"]
+					reporters: [] // pass :runner to avoid logging STARTED & SKIPPED
 				}
 			},
 			remote: {
 				options: {
 					runType: "runner",
 					config: "tests/intern",
-					reporters: ["runner"]
+					reporters: [] // pass :runner to avoid logging STARTED & SKIPPED
 				}
 			},
 			browserstack: {
 				options: {
 					runType: "runner",
 					config: "tests/intern.browserstack",
-					reporters: ["runner"]
+					reporters: [] // pass :runner to avoid logging STARTED & SKIPPED
 				}
 			}
 		},
@@ -138,13 +138,15 @@ module.exports = function (grunt) {
 	
 	// Testing.
 	// always specify the target e.g. grunt test:remote, grunt test:remote
-	// then add on any other flags afterwards e.g. console, lcovhtml
+	// then add on any other flags afterwards e.g. runner, console, lcovhtml
 	var testTaskDescription = "Run this task instead of the intern task directly! \n" +
 		"Always specify the test target e.g. \n" +
 		"grunt test:local\n" +
 		"grunt test:local.android\n" +
 		"grunt test:local.ios\n" +
 		"grunt test:remote\n\n" +
+		"To override the default reporter 'customRunner' with the 'runner' reporter pass the runner flag e.g. \n" +
+		"grunt test:local:runner\n" +
 		"Add any optional reporters via a flag e.g. \n" +
 		"grunt test:local:console\n" +
 		"grunt test:local:lcovhtml\n" +
@@ -163,9 +165,18 @@ module.exports = function (grunt) {
 			addReporter("lcovhtml");
 		}
 
+		if (this.flags.runner) {
+			addReporter("runner");
+		}
+
 		if (this.flags.console) {
 			addReporter("console");
 		}
+
+		if (!this.flags.runner || this.flags.customRunner) {
+			addReporter("deliteful/tests/customRunner");
+		}
+
 		grunt.task.run("intern:" + target);
 	});
 };

--- a/tests/customRunner.js
+++ b/tests/customRunner.js
@@ -1,0 +1,150 @@
+define([
+	"intern/dojo/node!istanbul/lib/collector",
+	"intern/dojo/node!istanbul/lib/report/text-summary",
+	"intern/dojo/node!istanbul/lib/report/text",
+	"intern/dojo/topic",
+	"intern/lib/args",
+	"intern/lib/util"
+], function (Collector, Reporter, DetailedReporter, topic, args, util) {
+
+	/**
+	 * A Custom intern reporter based upon the intern/lib/reporters/runner
+	 *
+	 * This custom reporter logs the /test/start and /test/skip and logs the number of skipped tests on /session/end
+	 * in addition to the things normally logged by the runner reporter.  The log output looks like this:
+	 * `delite/Scrollable`.  Any text passed to skip will be appended to the end of the message.
+	 * @example
+	 * STARTED Test  'main - StarRating tests - tab order' on safari 7.0.6 on MAC:
+	 * -SKIPPED Test 'main - StarRating tests - tab order' on safari 7.0.6 on MAC:
+	 * *FAILED Test main - Checkbox - functional - Checkbox behavior on firefox 31.0 on XP:
+	 */
+	// empty session is for the test runner itself
+	var sessions = { "": {} },
+		reporter = new Reporter(),
+		detailedReporter = new DetailedReporter(),
+		hasErrors = false;
+
+	return {
+		"/proxy/start": function (config) {
+			console.log("Listening on 0.0.0.0:" + config.port);
+		},
+
+		"/deprecated": function (name, replacement, extra) {
+			console.warn(name + " is deprecated." +
+				(replacement ?
+					" Use " + replacement + " instead." :
+					" Please open a ticket at https://github.com/theintern/intern/issues if you still require access " +
+					"to this command through the Command object.") +
+				(extra ? " " + extra : "")
+			);
+		},
+
+		"/session/start": function (remote) {
+			sessions[remote.sessionId] = { remote: remote };
+			console.log("Initialised " + remote.environmentType);
+		},
+
+		"/test/start": function (test) {
+			console.error("STARTED  Test '" + test.id + "' on " + sessions[test.sessionId].remote.environmentType +
+				":");
+		},
+
+		// Any text passed to skip will be appended to the end of the message.
+		"/test/skip": function (test) {
+			console.error("-SKIPPED Test '" + test.id + "' on " + sessions[test.sessionId].remote.environmentType +
+				": " + test.skipped);
+		},
+
+		"/session/end": function (remote) {
+			var session = sessions[remote.sessionId],
+				suite = session.suite;
+			if (session.coverage) {
+				reporter.writeReport(session.coverage);
+			}
+			else {
+				console.log("No unit test coverage for " + remote.environmentType);
+			}
+
+			// TODO: Unit tests are reported but functional tests are not. The functional tests are reported in the
+			// grand total, however.
+			console.log("%s: %d/%d tests failed (%d skipped)", remote.environmentType,
+				suite.numFailedTests, suite.numTests, suite.numSkippedTests);
+		},
+
+		"/test/fail": function (test) {
+			console.error("*FAILED Test  '" + test.id + "' on " + sessions[test.sessionId].remote.environmentType +
+				":");
+			util.logError(test.error);
+		},
+
+		"/error": function (error) {
+			util.logError(error);
+			hasErrors = true;
+		},
+
+		"/coverage": function (sessionId, coverage) {
+			var session = sessions[sessionId];
+			session.coverage = session.coverage || new Collector();
+			session.coverage.add(coverage);
+		},
+
+		"/suite/end": function (suite) {
+			if (suite.name === "main") {
+				if (!sessions[suite.sessionId]) {
+					args.proxyOnly || console.warn("BUG: /suite/end was received for session " + suite.sessionId +
+						" without a /session/start");
+					return;
+				}
+
+				sessions[suite.sessionId].suite = suite;
+			}
+		},
+
+		"/runner/end": function () {
+			var collector = new Collector(),
+				numEnvironments = 0,
+				numTests = 0,
+				numFailedTests = 0,
+				numSkippedTests = 0;
+
+			for (var k in sessions) {
+				var session = sessions[k];
+				session.coverage && collector.add(session.coverage.getFinalCoverage());
+
+				if (k !== "") {
+					++numEnvironments;
+					numTests += session.suite.numTests;
+					numFailedTests += session.suite.numFailedTests;
+					numSkippedTests += session.suite.numSkippedTests;
+				}
+			}
+
+			// add a newline between test results and coverage results for prettier output
+			console.log("");
+
+			if (collector.files().length > 0) {
+				detailedReporter.writeReport(collector);
+			}
+
+			var message = "TOTAL: tested %d platforms, %d/%d tests failed";
+
+			if (numSkippedTests) {
+				message += " (" + numSkippedTests + " skipped)";
+			}
+
+			if (hasErrors && !numFailedTests) {
+				message += "; fatal error occurred";
+			}
+
+			console.log(message, numEnvironments, numFailedTests, numTests);
+		},
+
+		"/tunnel/start": function () {
+			console.log("Starting tunnel...");
+		},
+
+		"/tunnel/status": function (tunnel, status) {
+			console.log(status);
+		}
+	};
+});

--- a/tests/functional/Button.js
+++ b/tests/functional/Button.js
@@ -49,10 +49,9 @@ define([
 			// keyb nav
 			// give the focus to the button to have a ref starting point in the chain
 			var remote = this.remote;
-			if (/safari|iphone|selendroid/.test(remote.environmentType.browserName)) {
+			if (/safari|iOS|selendroid/.test(remote.environmentType.browserName)) {
 				// SafariDriver doesn't support sendKeys
-				console.log("Skipping test: key nav as sendKeys not supported on Safari");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support sendKeys.");
 			}
 			return remote
 				.execute("return document.getElementById('b0').focus();")
@@ -86,9 +85,8 @@ define([
 				//
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/iphone|selendroid/.test(remote.environmentType.browserName)) {
-				console.log("Skipping test: 'Button Form' on this platform.");
-				return remote.end();
+			if (/selendroid/.test(remote.environmentType.browserName)) {
+				return this.skip();
 			}
 			return loadFile(remote, "./Button.html")
 				.findById("form1")

--- a/tests/functional/Checkbox.js
+++ b/tests/functional/Checkbox.js
@@ -49,10 +49,9 @@ define([
 			// keyb nav
 			// give the focus to the button to have a ref starting point in the chain
 			var remote = this.remote;
-			if (/safari|iphone|selendroid/.test(remote.environmentType.browserName)) {
+			if (/safari|iOS|selendroid/.test(remote.environmentType.browserName)) {
 				// SafariDriver doesn't support sendKeys
-				console.log("Skipping test: key nav as sendKeys not supported on Safari");
-				return remote.end();
+			    return this.skip("SafariDriver doesn't support sendKeys.");
 			}
 			return remote
 				.execute("return document.getElementById('b1').focus();")
@@ -87,9 +86,8 @@ define([
 				//
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/iphone|selendroid/.test(remote.environmentType.browserName)) {
-				console.log("Skipping test: 'Checkbox Form' on this platform.");
-				return remote.end();
+			if (/iOS|selendroid/.test(remote.environmentType.browserName)) {
+				return this.skip();
 			}
 			return loadFile(remote, "./Checkbox.html")
 				.findById("form1")

--- a/tests/functional/Combobox.js
+++ b/tests/functional/Combobox.js
@@ -20,10 +20,8 @@ define([
 		"Combobox Form submit": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/iphone|selendroid/.test(remote.environmentType.browserName)) {
-				console.log("Skipping test: 'Combobox Form submit' on browser: " +
-					remote.environmentType.browserName);
-				return remote.end();
+			if (/iOS|selendroid/.test(remote.environmentType.browserName)) {
+				return this.skip();
 			}
 			return loadFile(this.remote, "./Combobox-decl.html")
 				.findById("form1")

--- a/tests/functional/Select.js
+++ b/tests/functional/Select.js
@@ -37,8 +37,8 @@ define(["intern",
 	// properties are correctly updated by the widget).
 	var checkKeyboardNavigationSingleSelection = function (remote, selectId) {
 		if (!/chrome|internet explorer/.test(remote.environmentType.browserName)) {
-			// Webdriver issues for now with FF 
-			console.log("Skipping checkKeyboardNavigationSingleSelection on " +
+			// Webdriver issues for now with FF (can not call skip inside function)
+			console.log("-SKIPPED checkKeyboardNavigationSingleSelection on " +
 				remote.environmentType.browserName);
 			return remote.end();
 		}
@@ -134,8 +134,8 @@ define(["intern",
 	var checkKeyboardNavigationMultipleSelection = function (remote, selectId) {
 		if (!/chrome/.test(remote.environmentType.browserName)) {
 			// Keyboard shortcuts for multi-selects are browser dependent.
-			// For now testing Chrome only.
-			console.log("Skipping checkKeyboardNavigationMultipleSelection on " +
+			// For now testing Chrome only. (can not call skip inside of function)
+			console.log("-SKIPPED checkKeyboardNavigationMultipleSelection on " +
 				remote.environmentType.browserName);
 			return remote.end();
 		}
@@ -341,10 +341,8 @@ define(["intern",
 		"Select Form submit": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/iphone|selendroid/.test(remote.environmentType.browserName)) {
-				console.log("Skipping test: 'Select Form submit' on browser: " +
-					remote.environmentType.browserName);
-				return remote.end();
+			if (/iOS|selendroid/.test(remote.environmentType.browserName)) {
+				return this.skip();
 			}
 			return remote
 				.findById("form1")

--- a/tests/functional/SidePane.js
+++ b/tests/functional/SidePane.js
@@ -29,10 +29,9 @@ define(["intern",
 		},
 		"test opening": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
-			if (/safari|iPhone|iPad/.test(this.remote.environmentType.browserName)
+			if (/safari|iOS/.test(this.remote.environmentType.browserName)
 				|| this.remote.environmentType.safari) {
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return this.remote.end();
+				return this.skip();
 			}
 			return this.remote.findById("showButton").click().end()
 				.sleep(800)
@@ -40,20 +39,18 @@ define(["intern",
 		},
 		"test closing": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
-			if (/safari|iPhone|iPad/.test(this.remote.environmentType.browserName)
+			if (/safari|iOS/.test(this.remote.environmentType.browserName)
 				|| this.remote.environmentType.safari) {
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return this.remote.end();
+				return this.skip();
 			}
 			return this.remote.findById("hideButton").click().end()
 				.sleep(800)
 				.then(isVisible(this.remote.findById("sp"), false));
 		}/*,
 		"test swipe closing": function () {
-			if (/safari|iPhone|iPad/.test(this.remote.environmentType.browserName)
+			if (/safari|iOS/.test(this.remote.environmentType.browserName)
 				|| this.remote.environmentType.safari) {
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return this.remote.end();
+				return this.skip();
 			}
 			return this.remote.findById("showButton").click().end().sleep(800)
 				.findById("page").moveMouseTo(30, 300).pressMouseButton().moveMouseTo(10, 300)

--- a/tests/functional/Slider.js
+++ b/tests/functional/Slider.js
@@ -24,7 +24,6 @@ define(["intern",
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
 			return remote.getCurrentUrl()
-				.then(logMessage(remote, this.id, "start..."))
 				.then(checkInitValue(remote, "singleSlider02", "25"))
 				.then(checkOnChange(remote, "singleSlider02", false))
 				.then(checkAria(remote, "singleSlider02", "d-slider-handle-max", "horizontal", "0", "100", "25"));
@@ -33,7 +32,6 @@ define(["intern",
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
 			return remote.getCurrentUrl()
-				.then(logMessage(remote, this.id, "start..."))
 				.then(checkInitValue(remote, "singleSlider03", "100"))
 				.then(checkOnChange(remote, "singleSlider03", false))
 				.then(checkAria(remote, "singleSlider03", "d-slider-handle-max", "horizontal", "0", "100", "100"));
@@ -42,9 +40,8 @@ define(["intern",
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
 			// SafariDriver doesn't support moveTo, see https://code.google.com/p/selenium/issues/detail?id=4136
-			if (/safari|iPhone|selendroid/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
-				return remote
-					.then(logMessage(remote, this.id, "no support for moveTo, skipping tests..."));
+			if (/safari|iOS|selendroid/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
+				return this.skip("SafariDriver doesn't support moveTo.");
 			} else {
 				return remote
 					.then(logMessage(remote, this.id, "click on handler..."))
@@ -65,7 +62,6 @@ define(["intern",
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
 			return remote.getCurrentUrl()
-				.then(logMessage(remote, this.id, "start..."))
 				.then(checkInitValue(remote, "rangeSlider01", "25,75"))
 				.then(checkOnChange(remote, "rangeSlider01", false))
 				.then(checkAria(remote, "rangeSlider01", "d-slider-handle-min", "horizontal", "0", "75", "25"))
@@ -75,7 +71,6 @@ define(["intern",
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
 			return remote.getCurrentUrl()
-				.then(logMessage(remote, this.id, "start..."))
 				.then(checkInitValue(remote, "rangeSlider02", "10,90"))
 				.then(checkOnChange(remote, "rangeSlider02", false))
 				.then(checkAria(remote, "rangeSlider02", "d-slider-handle-min", "horizontal", "0", "90", "10"))
@@ -85,7 +80,6 @@ define(["intern",
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
 			return remote.getCurrentUrl()
-				.then(logMessage(remote, this.id, "start..."))
 				.then(checkInitValue(remote, "rangeSlider03", "80,100"))
 				.then(checkOnChange(remote, "rangeSlider03", false))
 				.then(checkAria(remote, "rangeSlider03", "d-slider-handle-min", "horizontal", "0", "100", "80"))
@@ -95,9 +89,8 @@ define(["intern",
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
 			// SafariDriver doesn't support moveTo, see https://code.google.com/p/selenium/issues/detail?id=4136
-			if (/safari|iPhone|selendroid/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
-				return remote
-					.then(logMessage(remote, this.id, "no support for moveTo, skipping tests..."));
+			if (/safari|iOS|selendroid/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
+				return this.skip("SafariDriver doesn't support moveTo.");
 			} else {
 				return remote
 					.then(logMessage(remote, this.id, "click on handler..."))
@@ -130,7 +123,6 @@ define(["intern",
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
 			return loadTestPage(remote, "./slider/slider-prg.html")
-				.then(logMessage(remote, this.id, "start..."))
 				.then(checkInitValue(remote, "singleSlider01", "50"))
 				.then(checkOnChange(remote, "singleSlider01", false))
 				.then(checkAria(remote, "singleSlider01", "d-slider-handle-max", "horizontal", "0", "100", "50"));
@@ -139,7 +131,6 @@ define(["intern",
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
 			return remote.getCurrentUrl()
-				.then(logMessage(remote, this.id, "start..."))
 				.then(checkInitValue(remote, "singleSlider02", "25"))
 				.then(checkOnChange(remote, "singleSlider02", false))
 				.then(checkAria(remote, "singleSlider02", "d-slider-handle-max", "horizontal", "0", "100", "25"));
@@ -148,7 +139,6 @@ define(["intern",
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
 			return remote.getCurrentUrl()
-				.then(logMessage(remote, this.id, "start..."))
 				.then(checkInitValue(remote, "singleSlider03", "100"))
 				.then(checkOnChange(remote, "singleSlider03", false))
 				.then(checkAria(remote, "singleSlider03", "d-slider-handle-max", "horizontal", "0", "100", "100"));
@@ -158,7 +148,6 @@ define(["intern",
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
 			return remote.getCurrentUrl()
-				.then(logMessage(remote, this.id, "start..."))
 				.then(checkInitValue(remote, "rangeSlider01", "25,75"))
 				.then(checkOnChange(remote, "rangeSlider01", false))
 				.then(checkAria(remote, "rangeSlider01", "d-slider-handle-min", "horizontal", "0", "75", "25"))
@@ -168,7 +157,6 @@ define(["intern",
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
 			return remote.getCurrentUrl()
-				.then(logMessage(remote, this.id, "start..."))
 				.then(checkInitValue(remote, "rangeSlider02", "10,90"))
 				.then(checkOnChange(remote, "rangeSlider02", false))
 				.then(checkAria(remote, "rangeSlider02", "d-slider-handle-min", "horizontal", "0", "90", "10"))
@@ -178,7 +166,6 @@ define(["intern",
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
 			return remote.getCurrentUrl()
-				.then(logMessage(remote, this.id, "start..."))
 				.then(checkInitValue(remote, "rangeSlider03", "80,100"))
 				.then(checkOnChange(remote, "rangeSlider03", false))
 				.then(checkAria(remote, "rangeSlider03", "d-slider-handle-min", "horizontal", "0", "100", "80"))

--- a/tests/functional/StarRating.js
+++ b/tests/functional/StarRating.js
@@ -129,7 +129,6 @@ define([
 		"read only ltr": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote, widgetId = "star";
-			console.log("# running test 'read only ltr'");
 			return remote
 				.get(require.toUrl("./StarRating.html"))
 				.then(pollUntilStarRatingReady(widgetId, intern.config.WAIT_TIMEOUT, intern.config.POLL_INTERVAL))
@@ -169,23 +168,22 @@ define([
 		},
 		"editable ltr": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
-			console.log("# running test 'editable ltr'");
 			return defaultEditableRatingTest(this.remote, "editablestar1", false, true, 0);
 		},
 		"editable half values ltr": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
-			console.log("# running test 'editable half values ltr'");
 			return defaultEditableRatingTest(this.remote, "editablestar2", true, true, 0);
 		},
 		"editable half values no zero setting ltr": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
-			console.log("# running test 'editable half values no zero setting ltr'");
 			return defaultEditableRatingTest(this.remote, "editablestar5", true, false, 0.5);
 		},
 		"editable programmatic onchange ltr": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
-			console.log("# running test 'editable programmatic onchange ltr'");
 			var remote = this.remote, id = "editablestar6";
+			if (/iOS/.test(remote.environmentType.browserName)) {
+				return this.skip();
+			}
 			return remote
 				.get(require.toUrl("./StarRating.html"))
 				.then(pollUntilStarRatingReady(id, intern.config.WAIT_TIMEOUT, intern.config.POLL_INTERVAL))
@@ -231,7 +229,6 @@ define([
 		},
 		"default": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
-			console.log("# running test 'default'");
 			var remote = this.remote, id = "defaultstar";
 			return remote
 			.get(require.toUrl("./StarRating.html"))
@@ -244,13 +241,11 @@ define([
 		"tab order": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/safari|iPhone|selendroid/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
+			if (/safari|iOS|selendroid/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
 				// SafariDriver doesn't support tabbing, see https://code.google.com/p/selenium/issues/detail?id=5403
 				// Same problem with selendroid and iOS, apparently
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support tabbing.");
 			}
-			console.log("# running test 'tab order'");
 			return remote
 			.get(require.toUrl("./StarRating.html"))
 			.then(pollUntil("return 'ready' in window && ready ? true : null;", [],
@@ -313,7 +308,6 @@ define([
 		},
 		"disabled": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
-			console.log("# running test 'disabled'");
 			var remote = this.remote, id = "starrating3";
 			return remote
 			.get(require.toUrl("./StarRating-form.html"))
@@ -326,7 +320,6 @@ define([
 		"form back button": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			console.log("# running test 'form back button'");
 			return remote
 			.get(require.toUrl("./StarRating-formback.html"))
 			.then(pollUntil("return 'ready' in window && ready ? true : null;", [],
@@ -342,8 +335,8 @@ define([
 			.then(function () {
 				// Safari driver does not support the back method
 				// see https://code.google.com/p/selenium/issues/detail?id=3771
-				if (/safari|iPhone|selendroid/.test(remote.environmentType.browserName)) {
-					console.log("Skipping 'back' on safari driver (not supported)");
+				if (/safari|iOS|selendroid/.test(remote.environmentType.browserName)) {
+					console.log("-SKIPPED 'back' on safari driver (not supported) on " + remote.environmentType);
 					return checkSubmitedParameters(remote, ["star1", "star2"], ["7", "2"]);
 				} else {
 					return checkSubmitedParameters(remote, ["star1", "star2"], ["7", "2"])
@@ -373,7 +366,6 @@ define([
 		"form values": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote, id = "starrating1";
-			console.log("# running test 'form values'");
 			return remote
 			.get(require.toUrl("./StarRating-form.html"))
 			.then(pollUntilStarRatingReady(id, intern.config.WAIT_TIMEOUT, intern.config.POLL_INTERVAL))

--- a/tests/functional/SwapView.js
+++ b/tests/functional/SwapView.js
@@ -77,10 +77,9 @@ define([
 		"SwapView swipe gesture (right->left)": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/safari|iphone|selendroid/.test(remote.environmentType.browserName)) {
+			if (/safari|iOS|selendroid/.test(remote.environmentType.browserName)) {
 				// SafariDriver doesn't support moveTo, see https://code.google.com/p/selenium/issues/detail?id=4136
-				console.log("Skipping test: SwapView swipe gesture (right->left) as moveTo not supported on Safari");
-				return remote.end();
+			    return this.skip("SafariDriver doesn't support moveTo.");
 			} else {
 				return remote
 					.findById("sv")
@@ -178,10 +177,9 @@ define([
 		"ViewIndicator update": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/safari|iphone|selendroid/.test(remote.environmentType.browserName)) {
+			if (/safari|iOS|selendroid/.test(remote.environmentType.browserName)) {
 				// SafariDriver doesn't support moveTo, see https://code.google.com/p/selenium/issues/detail?id=4136
-				console.log("Skipping test: ViewIndicator update as moveTo not supported on Safari");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support moveTo.");
 			} else {
 				return remote
 					.execute("return document.getElementById('vi').children[0].className;")
@@ -206,10 +204,9 @@ define([
 		"SwapView swipe gesture (left->right)": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/safari|iphone|selendroid/.test(remote.environmentType.browserName)) {
+			if (/safari|iOS|selendroid/.test(remote.environmentType.browserName)) {
 				// SafariDriver doesn't support moveTo, see https://code.google.com/p/selenium/issues/detail?id=4136
-				console.log("Skipping test: SwapView swipe gesture (left->right) as moveTo not supported on Safari");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support moveTo.");
 			} else {
 				return remote
 					.findById("sv")
@@ -307,10 +304,9 @@ define([
 		"ViewIndicator click dot": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/safari|iphone|selendroid/.test(remote.environmentType.browserName)) {
+			if (/safari|iOS|selendroid/.test(remote.environmentType.browserName)) {
 				// SafariDriver doesn't support moveTo, see https://code.google.com/p/selenium/issues/detail?id=4136
-				console.log("Skipping test: ViewIndicator click as moveTo not supported on Safari");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support moveTo.");
 			}
 			return remote
 				.findById("vi")
@@ -343,10 +339,9 @@ define([
 		"ViewIndicator click left": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/safari|iphone|selendroid/.test(remote.environmentType.browserName)) {
+			if (/safari|iOS|selendroid/.test(remote.environmentType.browserName)) {
 				// SafariDriver doesn't support moveTo, see https://code.google.com/p/selenium/issues/detail?id=4136
-				console.log("Skipping test: ViewIndicator click as moveTo not supported on Safari");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support moveTo.");
 			}
 			return remote
 				.findById("vi")
@@ -379,10 +374,9 @@ define([
 		"ViewIndicator click right": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/safari|iphone|selendroid/.test(remote.environmentType.browserName)) {
+			if (/safari|iOS|selendroid/.test(remote.environmentType.browserName)) {
 				// SafariDriver doesn't support moveTo, see https://code.google.com/p/selenium/issues/detail?id=4136
-				console.log("Skipping test: ViewIndicator click as moveTo not supported on Safari");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support moveTo.");
 			}
 			return remote
 				.findById("vi")
@@ -415,11 +409,10 @@ define([
 		"SwapView keyboard accessibility": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/safari|iphone|selendroid/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
+			if (/safari|iOS|selendroid/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
 				// SafariDriver doesn't support tabbing, see https://code.google.com/p/selenium/issues/detail?id=5403
 				// Same problem with selendroid and iOS, apparently
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support tabbing.");
 			}
 			return remote
 				// keyb nav

--- a/tests/functional/Switch.js
+++ b/tests/functional/Switch.js
@@ -25,10 +25,9 @@ define([
 		"Switch behavior": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/safari|iphone|selendroid/.test(remote.environmentType.browserName)) {
+			if (/safari|iOS|selendroid/.test(remote.environmentType.browserName)) {
 				// SafariDriver doesn't support moveTo, see https://code.google.com/p/selenium/issues/detail?id=4136
-				console.log("Skipping test: Switch behavior as moveTo not supported on Safari");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support moveTo.");
 			} else {
 				return loadFile(remote, "./Switch.html")
 					.findById("sw1")

--- a/tests/functional/Toaster.js
+++ b/tests/functional/Toaster.js
@@ -163,7 +163,6 @@ define(["intern",
 						intern.config.WAIT_TIMEOUT, intern.config.POLL_INTERVAL));
 		},
 		"Check Aria/initial nb of messages/posting": function () {
-			console.log("# running test 'default'");
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
 			return checkAriaAttr(remote, "default")
@@ -183,7 +182,6 @@ define(["intern",
 				});
 		},
 		"Check toaster stacking permanent messages": function () {
-			console.log("# running test 'check permanent message stacking'");
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
 			return remote
@@ -241,7 +239,6 @@ define(["intern",
 		// TODO: this test case doesn't pass due to a dpointer issue which has been reported here
 		// https://github.com/ibm-js/dpointer/issues/23
 //		"Check message dismissal": function () {
-//			console.log("# running test 'check message dismissal'");
 //			var remote = this.remote;
 //			return remote
 //				.get(require.toUrl(PAGE))
@@ -274,7 +271,6 @@ define(["intern",
 //				.end();
 //		},
 		"Check message duration": function () {
-			console.log("# running test 'check message durations'");
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
 			return remote
@@ -294,7 +290,6 @@ define(["intern",
 				.end();
 		},
 		"Check message types": function () {
-			console.log("# running test 'check message types'");
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
 

--- a/tests/functional/list/AriaListboxTests.js
+++ b/tests/functional/list/AriaListboxTests.js
@@ -118,10 +118,9 @@ define(["intern",
 		"keyboard navigation with default renderers": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/safari|iPhone/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
+			if (/safari|iOS/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
 				// SafariDriver doesn't support tabbing, see https://code.google.com/p/selenium/issues/detail?id=5403
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support tabbing.");
 			}
 			return remote
 			.get(require.toUrl("./listbox-prog-1.html"))
@@ -196,10 +195,9 @@ define(["intern",
 		"keyboard navigation with categorized items": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/safari|iPhone/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
+			if (/safari|iOS/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
 				// SafariDriver doesn't support tabbing, see https://code.google.com/p/selenium/issues/detail?id=5403
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support tabbing.");
 			}
 			return remote
 			.get(require.toUrl("./listbox-mark-3.html"))
@@ -248,10 +246,9 @@ define(["intern",
 		"keyboard multiple selection": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/safari|iPhone/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
+			if (/safari|iOS/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
 				// SafariDriver doesn't support tabbing, see https://code.google.com/p/selenium/issues/detail?id=5403
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support tabbing.");
 			}
 			return remote
 			.get(require.toUrl("./listbox-mark-1.html"))
@@ -297,10 +294,9 @@ define(["intern",
 		"keyboard single selection": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/safari|iPhone/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
+			if (/safari|iOS/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
 				// SafariDriver doesn't support tabbing, see https://code.google.com/p/selenium/issues/detail?id=5403
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support tabbing.");
 			}
 			return remote
 			.get(require.toUrl("./listbox-mark-2.html"))
@@ -405,10 +401,9 @@ define(["intern",
 		"keyboard search": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/safari|iPhone/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
+			if (/safari|iOS/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
 				// SafariDriver doesn't support tabbing, see https://code.google.com/p/selenium/issues/detail?id=5403
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support tabbing.");
 			}
 			return remote
 			.get(require.toUrl("./listbox-mark-1.html"))

--- a/tests/functional/list/ListTests.js
+++ b/tests/functional/list/ListTests.js
@@ -265,10 +265,9 @@ define(["intern",
 		"keyboard navigation with default renderers": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/safari|iPhone/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
+			if (/safari|iOS/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
 				// SafariDriver doesn't support tabbing, see https://code.google.com/p/selenium/issues/detail?id=5403
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support tabbing.");
 			}
 			return remote
 			.get(require.toUrl("./list-prog-1.html"))
@@ -343,10 +342,9 @@ define(["intern",
 		"keyboard navigation with custom renderers": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			if (/safari|iPhone/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
+			if (/safari|iOS/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
 				// SafariDriver doesn't support tabbing, see https://code.google.com/p/selenium/issues/detail?id=5403
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support tabbing.");
 			}
 			return remote
 			.get(require.toUrl("./list-cust-2.html"))
@@ -539,8 +537,7 @@ define(["intern",
 			var remote = this.remote;
 			if (/safari|iPhone/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
 				// SafariDriver doesn't support tabbing, see https://code.google.com/p/selenium/issues/detail?id=5403
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support tabbing.");
 			}
 			return remote
 			.get(require.toUrl("./list-mark-2.html"))
@@ -647,8 +644,7 @@ define(["intern",
 			var remote = this.remote;
 			if (/safari|iPhone/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
 				// SafariDriver doesn't support tabbing, see https://code.google.com/p/selenium/issues/detail?id=5403
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support tabbing.");
 			}
 			return remote
 			.get(require.toUrl("./list-mark-5.html"))
@@ -755,8 +751,7 @@ define(["intern",
 			var remote = this.remote;
 			if (/safari|iPhone/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
 				// SafariDriver doesn't support tabbing, see https://code.google.com/p/selenium/issues/detail?id=5403
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support tabbing.");
 			}
 			return remote
 			.get(require.toUrl("./list-mark-1.html"))
@@ -813,8 +808,7 @@ define(["intern",
 			var remote = this.remote;
 			if (/safari|iPhone/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
 				// SafariDriver doesn't support tabbing, see https://code.google.com/p/selenium/issues/detail?id=5403
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support tabbing.");
 			}
 			return remote
 			.get(require.toUrl("./list-cust-1.html"))

--- a/tests/functional/list/PageableTests.js
+++ b/tests/functional/list/PageableTests.js
@@ -53,13 +53,11 @@ define(["intern",
 			// see https://github.com/ibm-js/deliteful/issues/280
 			if (remote.environmentType.browserName === "internet explorer" &&
 					remote.environmentType.version === "10") {
-				console.log("WARNING: PageableList not supported on IE10");
-				return remote.end();
+				return this.skip("WARNING: PageableList not supported on IE10");
 			}
-			if (/safari|iPhone/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
+			if (/safari|iOS/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
 				// SafariDriver doesn't support tabbing, see https://code.google.com/p/selenium/issues/detail?id=5403
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support tabbing.");
 			}
 			var listId = "pageable-prog-1";
 			return remote
@@ -121,13 +119,11 @@ define(["intern",
 			// see https://github.com/ibm-js/deliteful/issues/280
 			if (remote.environmentType.browserName === "internet explorer" &&
 					remote.environmentType.version === "10") {
-				console.log("WARNING: PageableList not supported on IE10");
-				return remote.end();
+				return this.skip("WARNING: PageableList not supported on IE10");
 			}
-			if (/safari|iPhone/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
+			if (/safari|iOS/.test(remote.environmentType.browserName) || remote.environmentType.safari) {
 				// SafariDriver doesn't support tabbing, see https://code.google.com/p/selenium/issues/detail?id=5403
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support tabbing.");
 			}
 			var listId = "pageable-prog-2";
 			return remote
@@ -178,13 +174,11 @@ define(["intern",
 			// see https://github.com/ibm-js/deliteful/issues/280
 			if (remote.environmentType.browserName === "internet explorer" &&
 					remote.environmentType.version === "10") {
-				console.log("WARNING: PageableList not supported on IE10");
-				return remote.end();
+				return this.skip("WARNING: PageableList not supported on IE10");
 			}
 			if (/chrome/.test(remote.environmentType.browserName)) {
 				// https://code.google.com/p/selenium/issues/detail?id=2766
-				console.log("Skipping test '" + this.parent.name + ": " + this.name + "' on this platform");
-				return remote.end();
+				return this.skip("SafariDriver doesn't support tabbing.");
 			}
 			return remote
 				.get(require.toUrl("./pageable-prog-8.html"))

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -31,7 +31,7 @@ define({
 		// Mobile
 		// Need to wait for Intern 2.1 to be able to run the tests on iOS (SauceLabs)
 		// see https://github.com/theintern/intern/issues/216
-		//{ platformName: "iOS", platformVersion: "7.1", browserName: "safari", deviceName: "iPhone Simulator",
+		//,{ platformName: "iOS", platformVersion: "7.1", browserName: "safari", deviceName: "iPhone Simulator",
 		//	"appium-version": "1.2.2", name: "deliteful" }
 	],
 

--- a/tests/unit/ViewIndicator.js
+++ b/tests/unit/ViewIndicator.js
@@ -4,7 +4,7 @@ define([
 	"requirejs-dplugins/jquery!attributes/classes",
 	"delite/register",
 	"deliteful/SwapView",
-	"deliteful/ViewIndicator",
+	"deliteful/ViewIndicator"
 ], function (registerSuite, assert, $, register) {
 	var container, vs;
 	var aaa, bbb, ccc, ddd;


### PR DESCRIPTION
...alling remote.end(), and added a customRunner intern reporter to log the starting and skipping of tests.  customRunner will log STARTED or SKIPPED along with the full test name and the platform info from remote.environmentType.  Along with this I have removed all of the console logs which were used to tell which tests were starting or being skipped.  I have also update tests checking for iPhone to use iOS instead, but I have not enabled the tests run on iOS yet, there is still one problem to be resolved on iOS.
