### PR TITLE
Package centered popup as distinct widget. Fixes #367

### DIFF
--- a/Combobox/ComboPopup.html
+++ b/Combobox/ComboPopup.html
@@ -1,0 +1,19 @@
+<template role="presentation"
+	requires="deliteful/LinearLayout, deliteful/Button">
+	<d-linear-layout style="height: 100%">
+		<input d-hidden="{{!(this.combobox.autoFilter && this.combobox.selectionMode !== 'multiple')}}"
+			attach-point="inputNode"
+			class="d-combobox-input"
+			role="combobox" autocomplete="off" autocapitalize="none" autocorrect="off"
+			aria-autocomplete="list" type="search"
+			placeholder="{{combobox.searchPlaceHolder}}">
+		<div attach-point="listNode"></div>
+		<d-linear-layout d-hidden="{{combobox.selectionMode !== 'multiple'}}"
+			vertical="false">
+			<button is="d-button" class="fill d-combo-cancel-button"
+				label="{{combobox.cancelMsg}}" on-click="{{cancelHandler}}"></button>
+			<button is="d-button" class="fill d-combo-ok-button"
+				label="{{combobox.okMsg}}" on-click="{{okHandler}}"></button>
+		</d-linear-layout>
+	</d-linear-layout>
+</template>

--- a/Combobox/ComboPopup.js
+++ b/Combobox/ComboPopup.js
@@ -1,0 +1,69 @@
+/** @module deliteful/ComboPopup */
+define([
+	"delite/register",
+	"requirejs-dplugins/jquery!attributes/classes",	// addClass()
+	"delite/Widget",
+	"delite/handlebars!./ComboPopup.html"
+], function (register, $, Widget, template) {
+	/**
+	 * Auxiliary widget used in some cases by deliteful/Combobox for displaying
+	 * a popup containing conditionally a search field and OK/Cancel buttons.
+	 * This widget is intended for being instanciated only by deliteful/Combobox;
+	 * it should not be instanciated directly. If needed, its template
+	 * (deliteful/Combobox/ComboPopup.html) can be customized.
+	 * @class module:deliteful/Combobox/ComboPopup
+	 * @augments module:delite/Widget
+	 */
+	return register("d-combo-popup", [HTMLElement, Widget],
+		/** @lends module:deliteful/ComboPopup# */ {
+		
+		baseClass: "d-combo-popup",
+		
+		template: template,
+		
+		/**
+		 * The instance of `deliteful/Combobox` for which this widget is used.
+		 * This property is set by Combobox when creating the popup, and it
+		 * is used in the template of ComboPopup for accessing the properties
+		 * of the Combobox.
+		 * @member {boolean} module:deliteful/Combobox/ComboPopup#combobox
+		 * @default null
+		 * @protected
+		 */
+		combobox: null,
+		
+		refreshRendering: function (oldValues) {
+			if ("combobox" in oldValues) {
+				if (this.combobox) {
+					var list = this.combobox.list;
+					if (list) {
+						list.placeAt(this.listNode, "replace");
+						// startup() is not called by Widget.placeAt because the parent of
+						// dropDown is not yet started, but startup() will be called by delite/popup
+						// when opening the dropdown.
+						$(list).addClass("fill");
+					}
+					this.combobox._prepareInput(this.inputNode);
+				}
+			}
+		},
+		
+		/**
+		 * Called when clicking the OK button of the popup.
+		 * @protected
+		 */
+		okHandler: function () {
+			this.combobox._validateMultiple(this.combobox.inputNode);
+			this.combobox.closeDropDown();
+		},
+		
+		/**
+		 * Called when clicking the Cancel button of the popup.
+		 * @protected
+		 */
+		cancelHandler: function () {
+			this.combobox.list.selectedItems = this.combobox._selectedItems;
+			this.combobox.closeDropDown();
+		}
+	});
+});

--- a/Combobox/themes/Combobox_template.less
+++ b/Combobox/themes/Combobox_template.less
@@ -33,7 +33,24 @@
 	opacity: 0.5;
 }
 
+.d-combo-popup {
+	/* Needed for the correct layout of its LinearLayout child */
+	display: block;
+}
+
+/* Applies to both the input inside the root node and the input */
+/* conditionally present inside the popup */
 .d-combobox-input {
+	.d-combobox-input-styles;
+	color: inherit;
+	font-family: inherit;
+	font-size: inherit;
+	line-height: inherit;
+}
+
+/* Applies to the input inside the root node but does not apply */
+/* to the input conditionally present inside the popup */
+.d-combobox .d-combobox-input {
 	height: 100%;
 	cursor: pointer;
 	
@@ -46,14 +63,6 @@
 		opacity: 0.5;
 		cursor: auto;
 	}
-}
-
-.d-combobox-input, .d-combobox-popup-input {
-	.d-combobox-input-styles;
-	color: inherit;
-	font-family: inherit;
-	font-size: inherit;
-	line-height: inherit;
 }
 
 .d-combobox .d-combobox-list-hidden {

--- a/Combobox/themes/bootstrap/Combobox.css
+++ b/Combobox/themes/bootstrap/Combobox.css
@@ -37,20 +37,13 @@
   cursor: auto;
   opacity: 0.5;
 }
+.d-combo-popup {
+  /* Needed for the correct layout of its LinearLayout child */
+  display: block;
+}
+/* Applies to both the input inside the root node and the input */
+/* conditionally present inside the popup */
 .d-combobox-input {
-  height: 100%;
-  cursor: pointer;
-  /* Necessary for Safari on iOS to avoid misplacement of the dropdown arrow */
-  /* due to the presence of the hidden input which stores the submitted value.*/
-  margin: 0;
-}
-.d-combobox-input[disabled],
-fieldset[disabled] .d-combobox-input {
-  opacity: 0.5;
-  cursor: auto;
-}
-.d-combobox-input,
-.d-combobox-popup-input {
   padding: 6px 12px;
   border: 1px solid #cccccc;
   border-radius: 4px;
@@ -59,12 +52,25 @@ fieldset[disabled] .d-combobox-input {
   font-size: inherit;
   line-height: inherit;
 }
-.d-combobox-input:focus,
-.d-combobox-popup-input:focus {
+.d-combobox-input:focus {
   /* defined in delite/themes/bootstrap/mixins.less */
   outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
+}
+/* Applies to the input inside the root node but does not apply */
+/* to the input conditionally present inside the popup */
+.d-combobox .d-combobox-input {
+  height: 100%;
+  cursor: pointer;
+  /* Necessary for Safari on iOS to avoid misplacement of the dropdown arrow */
+  /* due to the presence of the hidden input which stores the submitted value.*/
+  margin: 0;
+}
+.d-combobox .d-combobox-input[disabled],
+fieldset[disabled] .d-combobox .d-combobox-input {
+  opacity: 0.5;
+  cursor: auto;
 }
 .d-combobox .d-combobox-list-hidden {
   display: none;

--- a/Combobox/themes/holodark/Combobox.css
+++ b/Combobox/themes/holodark/Combobox.css
@@ -38,20 +38,13 @@
   cursor: auto;
   opacity: 0.5;
 }
+.d-combo-popup {
+  /* Needed for the correct layout of its LinearLayout child */
+  display: block;
+}
+/* Applies to both the input inside the root node and the input */
+/* conditionally present inside the popup */
 .d-combobox-input {
-  height: 100%;
-  cursor: pointer;
-  /* Necessary for Safari on iOS to avoid misplacement of the dropdown arrow */
-  /* due to the presence of the hidden input which stores the submitted value.*/
-  margin: 0;
-}
-.d-combobox-input[disabled],
-fieldset[disabled] .d-combobox-input {
-  opacity: 0.5;
-  cursor: auto;
-}
-.d-combobox-input,
-.d-combobox-popup-input {
   padding: 6px 12px;
   border: 1px solid #cccccc;
   border-radius: 4px;
@@ -60,12 +53,25 @@ fieldset[disabled] .d-combobox-input {
   font-size: inherit;
   line-height: inherit;
 }
-.d-combobox-input:focus,
-.d-combobox-popup-input:focus {
+.d-combobox-input:focus {
   /* defined in delite/themes/bootstrap/mixins.less */
   outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
+}
+/* Applies to the input inside the root node but does not apply */
+/* to the input conditionally present inside the popup */
+.d-combobox .d-combobox-input {
+  height: 100%;
+  cursor: pointer;
+  /* Necessary for Safari on iOS to avoid misplacement of the dropdown arrow */
+  /* due to the presence of the hidden input which stores the submitted value.*/
+  margin: 0;
+}
+.d-combobox .d-combobox-input[disabled],
+fieldset[disabled] .d-combobox .d-combobox-input {
+  opacity: 0.5;
+  cursor: auto;
 }
 .d-combobox .d-combobox-list-hidden {
   display: none;

--- a/Combobox/themes/ios/Combobox.css
+++ b/Combobox/themes/ios/Combobox.css
@@ -38,20 +38,13 @@
   cursor: auto;
   opacity: 0.5;
 }
+.d-combo-popup {
+  /* Needed for the correct layout of its LinearLayout child */
+  display: block;
+}
+/* Applies to both the input inside the root node and the input */
+/* conditionally present inside the popup */
 .d-combobox-input {
-  height: 100%;
-  cursor: pointer;
-  /* Necessary for Safari on iOS to avoid misplacement of the dropdown arrow */
-  /* due to the presence of the hidden input which stores the submitted value.*/
-  margin: 0;
-}
-.d-combobox-input[disabled],
-fieldset[disabled] .d-combobox-input {
-  opacity: 0.5;
-  cursor: auto;
-}
-.d-combobox-input,
-.d-combobox-popup-input {
   padding: 6px 12px;
   border: 1px solid #cccccc;
   border-radius: 4px;
@@ -60,12 +53,25 @@ fieldset[disabled] .d-combobox-input {
   font-size: inherit;
   line-height: inherit;
 }
-.d-combobox-input:focus,
-.d-combobox-popup-input:focus {
+.d-combobox-input:focus {
   /* defined in delite/themes/bootstrap/mixins.less */
   outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
+}
+/* Applies to the input inside the root node but does not apply */
+/* to the input conditionally present inside the popup */
+.d-combobox .d-combobox-input {
+  height: 100%;
+  cursor: pointer;
+  /* Necessary for Safari on iOS to avoid misplacement of the dropdown arrow */
+  /* due to the presence of the hidden input which stores the submitted value.*/
+  margin: 0;
+}
+.d-combobox .d-combobox-input[disabled],
+fieldset[disabled] .d-combobox .d-combobox-input {
+  opacity: 0.5;
+  cursor: auto;
 }
 .d-combobox .d-combobox-list-hidden {
   display: none;

--- a/docs/Combobox.md
+++ b/docs/Combobox.md
@@ -15,7 +15,7 @@ Characteristics:
 * Provides optional interactive filtering of list of options (single selection mode only). 
 * The rendering of the popup is multi-channel responsive: by default, the popup is displayed
 on desktop below/above the main element, while on mobile it is displayed in a centered
-overlay.
+overlay (an instance of deliteful/Combobox/ComboPopup is used in this case).
 
 
 *Example of deliteful/Combobox (single choice mode, on desktop browser):*
@@ -220,10 +220,11 @@ The following table lists the CSS classes that can be used to style the Combobox
 
 |Class name/selector|Applies to|
 |----------|----------|
-|d-combobox|Combobox widget node.
-|d-combobox-input|The inner native `<input>` node on desktop.
-|d-combobox-popup-input|The inner native `input` node inside the centered popup displayed on mobile.
+|d-combobox|Combobox widget root node.
+|d-combobox-input|The native `<input>` nodes used by the Combobox widget.
 |d-combobox-list|The List widget displayed inside the popup.
+|d-combo-ok-button|The OK button used in some cases inside the popup.
+|d-combo-cancel-button|The Cancel button used in some cases inside the popup.
 
 
 <a name="enterprise"></a>


### PR DESCRIPTION
Implementation of #367.

To avoid mixing in this PR unrelated changes, I will do further changes separately:
* Cope with the recent changes in delite/FormValueWidget (https://github.com/ibm-js/delite/commit/00f0b74736e4b1a9473ef0c1a1d8ed5971f15bcd ). Since this change, Combobox lost its ability to handle the readOnly attribute of the input element, because now FormValueWidget's own handling of this attribute has the last word on it.
* Styling improvements to improve the rendering (including for vertical alignment of text and arrow in IE, and rendering of inputs of type="search").
* And of course Combobox' API for creating the popup will change again with the implementation of #366 (multi-channel policy) and the overall design of Combobox/ComboPopup will be impacted by #179 (Seach/FilterBox / FilteredList).