### PR TITLE
Multichannel infrastructure and its use by Combobox (and ResponsiveColumns). Fixes #366

### DIFF
--- a/ResponsiveColumns.js
+++ b/ResponsiveColumns.js
@@ -3,8 +3,9 @@ define([
 	"requirejs-dplugins/jquery!attributes/classes",
 	"delite/register",
 	"delite/DisplayContainer",
+	"./channelBreakpoints",
 	"delite/theme!./ResponsiveColumns/themes/{{theme}}/ResponsiveColumns.css"
-], function ($, register, DisplayContainer) {
+], function ($, register, DisplayContainer, channelBreakpoints) {
 	/**
 	 * A container that lays out its children according to the screen width. This widget relies on CSS media queries
 	 * (http://www.w3.org/TR/css3-mediaqueries). You can define any number of screen classes by setting the breakpoints
@@ -38,10 +39,17 @@ define([
 			 * To facilitate writing markup you can use single quotes when defining this property, single quotes
 			 * will be replaced by double quotes before interpreted by `JSON.parse`.
 			 *
+			 * The default value of `breakpoints` uses three breakpoints: `small`, `medium`, and `large`.
+			 * The value of `large` is an empty string. The default values of the breakpoints `small`
+			 * and `medium` are determined by the values of properties `smallScreen"` and `"mediumScreen"`
+			 * of `deliteful/channelBreakpoints`, and can be configured statically using `require.config()`.
+			 * For details, see the documentation of `deliteful/channelBreakpoints`.
 			 * @member {string}
-			 * @default "{'small': '480px', 'medium': '1024px', large: ''}"
+			 * @default "{'small': '480px', 'medium': '1024px', 'large': ''}"
 			 */
-			breakpoints: "{'small': '480px', 'medium': '1024px', 'large': ''}",
+			breakpoints: "{'small': '" + channelBreakpoints.smallScreen +
+				"', 'medium': '" + channelBreakpoints.mediumScreen +
+				"', 'large': ''}",
 
 			/**
 			 * The current screen class currently applied by the container.

--- a/channelBreakpoints.js
+++ b/channelBreakpoints.js
@@ -21,7 +21,7 @@ define(["module"],
 	 * for instance:
 	 * 
 	 * ```html
-	 * <script>
+	 * &lt;script>
 	 *   // configuring RequireJS
 	 *   require.config({
 	 *     ...
@@ -32,7 +32,7 @@ define(["module"],
 	 *       }
 	 *     }
 	 *   });
-	 * </script>
+	 * &lt;/script>
 	 * ```
 	 * 
 	 * @module deliteful/channelBreakpoints

--- a/channelBreakpoints.js
+++ b/channelBreakpoints.js
@@ -1,0 +1,59 @@
+/** @module deliteful/channelBreakpoints */
+define(["module"],
+	function (module) {
+	
+	var config = module.config();
+	
+	/**
+	 * This module returns an object containing properties that define values for breakpoints
+	 * of CSS media queries based on screen size:
+	 * 
+	 * - `smallScreen`: defines the screen size limit between phone-like and tablet-like
+	 * channels.
+	 * - `mediumScreen`: defines the screen size limit between tablet-like and desktop-like
+	 * channels.
+	 * 
+	 * The values of the breakpoints are used by CSS media queries of `deliteful/features`
+	 * for setting the `has()`-flags `"phone-like-channel"`, `"tablet-like-channel"`, and
+	 * `"desktop-like-channel"`.
+	 * 
+	 * The default values of the breakpoints can be configured using `require.config()`,
+	 * for instance:
+	 * 
+	 * ```html
+	 * <script>
+	 *   // configuring RequireJS
+	 *   require.config({
+	 *     ...
+	 *     config: {
+	 *       "deliteful/channelBreakpoints": {
+	 *         smallScreen: "280px",
+	 *         mediumScreen: "724px"
+	 *       }
+	 *     }
+	 *   });
+	 * </script>
+	 * ```
+	 * 
+	 * @module deliteful/channelBreakpoints
+	 */
+	return /** @lends module:deliteful/channelBreakpoints# */ {
+		/**
+		 * The maximum screen size value for small screens.
+		 * Used as breakpoint by a CSS media query of `deliteful/features` as screen size
+		 * threshold between the phone-like and the table-like channels.
+		 * @member {string}
+		 * @default "480px"
+		 */
+		smallScreen: config.smallScreen || "480px",
+		
+		/**
+		 * The maximum screen size value for medium screens.
+		 * Used as breakpoint by a CSS media query of `deliteful/features` as screen size
+		 * threshold between the tablet-like and the desktop-like channels.
+		 * @member {string}
+		 * @default "1024px"
+		 */
+		mediumScreen: config.mediumScreen || "1024px"
+	};
+});

--- a/docs/Combobox.md
+++ b/docs/Combobox.md
@@ -9,14 +9,11 @@ title: deliteful/Combobox
 [`deliteful/list/List`](./list/List.md) widget for
 displaying the list of options. 
 
-Characteristics:
-* It allows to benefit from the customization mechanism of the list item rendering.
+Main features:
+* Allows to benefit from the customization mechanism of the list item rendering.
 * Provides single and multiple selection modes.
 * Provides optional interactive filtering of list of options (single selection mode only). 
-* The rendering of the popup is multi-channel responsive: by default, the popup is displayed
-on desktop below/above the main element, while on mobile it is displayed in a centered
-overlay (an instance of deliteful/Combobox/ComboPopup is used in this case).
-
+* Multichannel rendering.
 
 *Example of deliteful/Combobox (single choice mode, on desktop browser):*
 
@@ -152,6 +149,21 @@ can be done on the List instance using the mapping API of
 See the [`delite/StoreMap`](/delite/docs/master/StoreMap.md) documentation for
 more information about the available mapping options, and the section
 [`Store capabilities`](./list/List.md#store) of List's documentation.
+
+### Multichannel rendering
+
+The widget provides multichannel rendering: the popup is displayed on
+large screens (desktop-like) below/above the main element, while on small and medium
+screens (phone-like and tablet-like), to optimize the usage of the available space,
+the popup is displayed in a centered overlay (an instance of `deliteful/Combobox/ComboPopup` 
+is used in this case).
+
+The channel is controlled by the value of the `has()` channel flags set by
+`deliteful/features` using CSS media queries depending on the screen size.
+See the [`deliteful/features`](./features.md) documentation
+for information about how to configure the channel. Also, see the 
+[`deliteful/channelBreakpoints`](./channelBreakpoints.md) documentation for information
+about how to customize the values of the screen size breakpoints used by the media queries.
 
 ### Value and form support
 

--- a/docs/ResponsiveColumns.md
+++ b/docs/ResponsiveColumns.md
@@ -94,7 +94,12 @@ Each child must have a `layout` property that defines values for "small", "mediu
 </d-responsive-columns>
 ```
 
-Both `breakpoints` and `layout` properties are string parsed internally by the standard `JSON.parse()`. To facilitate writing markup you can use single quotes when defining these properties, single quotes will be replaced by double quotes before interpreted by `JSON.parse`.
+Both `breakpoints` and `layout` properties are strings parsed internally by the standard `JSON.parse()`. To facilitate writing markup you can use single quotes when defining these properties, single quotes will be replaced by double quotes before interpreted by `JSON.parse`.
+
+Note that the widget computes the default value of its `breakpoints` property using the 
+values of the breakpoins provided by the `deliteful/channelBreakpoints` module. 
+See the [`deliteful/channelBreakpoints`](./channelBreakpoints.md) documentation
+for information about how to statically customize these default breakpoint values.
 
 <a name="events"></a>
 ## Events

--- a/docs/channelBreakpoints.md
+++ b/docs/channelBreakpoints.md
@@ -1,0 +1,64 @@
+---
+layout: default
+title: deliteful/channelBreakpoints
+---
+
+# deliteful/channelBreakpoints
+
+This module returns an object containing properties that define values for breakpoints
+of CSS media queries based on screen size:
+
+* `smallScreen`: defines the screen size limit between phone-like and tablet-like
+channels.
+* `mediumScreen`: defines the screen size limit between tablet-like and desktop-like
+channels.
+
+The values of the breakpoints are used by CSS media queries of `deliteful/features` for
+setting the `has()`-flags `"phone-like-channel"`, `"tablet-like-channel"`, 
+and `"desktop-like-channel"`. For more information, see the [`deliteful/features`](./features.md)
+documentation.
+
+
+## Using deliteful/channelBreakpoints
+
+Multichannel widgets (such as [`deliteful/Combobox`](./Combobox.md)) typically do
+not use `channelBreakpoints` directly. Instead, they rely on the channel `has()` flags
+set by [`deliteful/features`](./features.md). These flags are set by `deliteful/features`
+using CSS media queries based on screen size and using the breakpoint values provided by
+`deliteful/channelBreakpoints`.
+
+Responsive widgets [`deliteful/ResponsiveColumns`](./ResponsiveColumns.md)) typically
+use their own CSS media queries and share the default breakpoint values with the 
+multichannel widgets by getting them from `deliteful/channelBreakpoints`, for instance:
+
+```js
+require(["deliteful/channelBreakpoints", ...],
+	function (channelBreakpoints, ...) {
+	var smallScreenBreakpoint = channelBreakpoints.smallScreen;
+	var mediumScreenBreakpoint = channelBreakpoints.mediumScreen;
+	// Use these values as default breakpoint values for creating media queries
+	...
+});
+```
+
+## Configuring deliteful/channelBreakpoints
+
+The default values of the breakpoints can be configured statically in a hashmap provided through
+[requirejs module configuration](http://requirejs.org/docs/api.html#config-moduleconfig), for
+instance:
+
+```html
+<script>
+  // configuring RequireJS
+  require.config({
+    ...
+    config: {
+      "deliteful/channelBreakpoints": {
+        smallScreen: "200px",
+        mediumScreen: "500px"
+      }
+    }
+  });
+</script>
+```
+

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,82 @@
+---
+layout: default
+title: deliteful/features
+---
+
+# deliteful/features
+
+This module leverages `requirejs-dplugins/has` and augments the `has()` tests with
+media query based tests, such that multichannel widgets can rely on the `has()` API
+for determining the channel.
+Using this approach in conjunction with an optimizing compiler at build time, it is possible
+to optimize out unwanted code paths for specific channel policies.
+
+The `deliteful/features` module sets the following `has`-features:
+
+* `has("phone-like-channel")`: `true` for small screens, `false` otherwise.
+* `has("tablet-like-channel")`: `true` for medium screens, `false` otherwise.
+* `has("desktop-like-channel")`: `true` for large screens, `false` otherwise.
+
+The flags are set depending on the screen size, using CSS media queries that compare the actual
+screen width (the `device-width` media feature) with the corresponding breakpoint values
+provided by `deliteful/channelBreakpoints`.
+
+Note that the screen size is the only criteria used for determining the channel. When a
+channel flag is set to `true`, the other channel flags are set to `false`.
+
+## Using deliteful/features
+
+Example of use for determining different code paths depending on the channel:
+
+```js
+require(["deliteful/features", ...], function (has, ...) {
+	if (has("phone-like-channel")) { // only for the phone channel (small screen)
+	  ...
+	} else { // tablet-like and desktop-like channels (medium and large screens)
+	  ...
+	}
+});
+```
+
+Example of conditional loading of dependent modules depending on the channel,
+using a chained ternary operator applied to the `deliteful/features` module used as
+a [requirejs plugin](http://requirejs.org/docs/plugins.html):
+
+```js
+require(["deliteful/features!phone-like-channel?./PhoneModule:tablet-like-channel?./TabletModule:./DesktopModule", ...],
+	function (Module, ...) {
+	// The Module argument points to the return value of either PhoneModule, TabletModule,
+	// or DesktopModule depending on the channel.
+	...
+});
+```
+
+
+## Configuring deliteful/features
+
+The channel flags can be configured statically in a hashmap provided through
+[requirejs module configuration](http://requirejs.org/docs/api.html#config-moduleconfig),
+for instance:
+
+```html
+<script>
+  // configuring RequireJS
+  require.config({
+    ...
+    config: {
+      "requirejs-dplugins/has": {
+        "phone-like-channel": false,
+        "tablet-like-channel": true,
+        "desktop-like-channel": false,
+      }
+    }
+  });
+</script>
+```
+Note that only one channel flag should be set to `true`.
+
+If the channel flags are not configured statically, they are computed dynamically using
+CSS media queries based on breakpoints values provided by `deliteful/channelBreakpoints`.
+The breakpoint values can be configured using `require.config()`.
+For details, see the documentation of [`deliteful/channelBreakpoints`](./channelBreakpoints.md).
+

--- a/features.js
+++ b/features.js
@@ -20,7 +20,7 @@
  * The channel can be configured statically using `require.config()`, for instance:
  * 
  * ```html
- * <script>
+ * &lt;script>
  *   // configuring RequireJS
  *   require.config({
  *     ...
@@ -32,7 +32,7 @@
  *       }
  *     }
  *   });
- * </script>
+ * &lt;/script>
  * ```
  * Note that only one channel flag should be set to `true`.
  * 

--- a/features.js
+++ b/features.js
@@ -1,0 +1,69 @@
+/**
+ * This module leverages `requirejs-dplugins/has` and sets `has()` flags that can be
+ * used by multichannel widgets to determine the required channel:
+ *
+ * - `has("phone-like-channel")`: `true` for small screens, `false` otherwise.
+ * - `has("tablet-like-channel")`: `true` for medium screens, `false` otherwise.
+ * - `has("desktop-like-channel")`: `true` for large screens, `false` otherwise.
+ * 
+ * These flags are set depending on the screen size, using CSS media queries that
+ * compare the actual screen width (the `device-width` media feature) with the corresponding
+ * breakpoint values provided by `deliteful/channelBreakpoints`. 
+ * 
+ * Note that the screen size is the only criteria used for determining
+ * the channel. When a channel flag is set to `true`, the other channel flags are set
+ * to `false`.
+ * 
+ * The default values of the breakpoints can be configured using `require.config()`.
+ * For details, see the documentation of `deliteful/channelBreakpoints`.
+ * 
+ * The channel can be configured statically using `require.config()`, for instance:
+ * 
+ * ```html
+ * <script>
+ *   // configuring RequireJS
+ *   require.config({
+ *     ...
+ *     config: {
+ *       "requirejs-dplugins/has": {
+ *         "phone-like-channel": false,
+ *         "tablet-like-channel": true,
+ *         "desktop-like-channel": false,
+ *       }
+ *     }
+ *   });
+ * </script>
+ * ```
+ * Note that only one channel flag should be set to `true`.
+ * 
+ * The module returns the `has()` function returned by the module `requirejs-dplugins/has`.
+ * 
+ * @module deliteful/features
+ */
+define(["requirejs-dplugins/has", "deliteful/channelBreakpoints"],
+	function (has, channelBreakpoints) {
+
+	// Use the device-width media feature rather than width, such that, on
+	// desktop/laptop, the selected channel does not depend on the actual size of the
+	// viewport. Thus, the selected channel depends only on the static characteristics
+	// of the device (its screen width), which fits the use-case of multichannel
+	// widgets that need a statically determined channel. Otherwise it would be confusing
+	// to get a different channel depending on whether the app is initially loaded
+	// in a small or large viewport.
+	var mqSmall = window.matchMedia("(min-device-width: " +
+		channelBreakpoints.smallScreen + ")");
+	var mqMedium = window.matchMedia("(min-device-width: " +
+		channelBreakpoints.mediumScreen + ")");
+	
+	has.add("phone-like-channel", function () {
+		return !mqSmall.matches && !mqMedium.matches;
+	});
+	has.add("tablet-like-channel", function () {
+		return mqSmall.matches && !mqMedium.matches;
+	});
+	has.add("desktop-like-channel", function () {
+		return mqSmall.matches && mqMedium.matches;
+	});
+	
+	return has;
+});

--- a/features.js
+++ b/features.js
@@ -43,26 +43,33 @@
 define(["requirejs-dplugins/has", "deliteful/channelBreakpoints"],
 	function (has, channelBreakpoints) {
 
-	// Use the device-width media feature rather than width, such that, on
+	// Notes:
+	// - Use the device-width media feature rather than width, such that, on
 	// desktop/laptop, the selected channel does not depend on the actual size of the
 	// viewport. Thus, the selected channel depends only on the static characteristics
 	// of the device (its screen width), which fits the use-case of multichannel
 	// widgets that need a statically determined channel. Otherwise it would be confusing
 	// to get a different channel depending on whether the app is initially loaded
 	// in a small or large viewport.
-	var mqSmall = window.matchMedia("(min-device-width: " +
+	// - We do not technically enforce the "small" breakpoint to be smaller than the
+	// medium one. Hence the apparently redundant checks of both media queries
+	// for the small and large channels.
+	
+	// matched by screens at least as large as the "small" breakpoint
+	var mqAboveSmall = window.matchMedia("(min-device-width: " +
 		channelBreakpoints.smallScreen + ")");
-	var mqMedium = window.matchMedia("(min-device-width: " +
+	// matched by screens at least as large as the "medium" breakpoint
+	var mqAboveMedium = window.matchMedia("(min-device-width: " +
 		channelBreakpoints.mediumScreen + ")");
 	
 	has.add("phone-like-channel", function () {
-		return !mqSmall.matches && !mqMedium.matches;
+		return !mqAboveSmall.matches && !mqAboveMedium.matches;
 	});
 	has.add("tablet-like-channel", function () {
-		return mqSmall.matches && !mqMedium.matches;
+		return mqAboveSmall.matches && !mqAboveMedium.matches;
 	});
 	has.add("desktop-like-channel", function () {
-		return mqSmall.matches && mqMedium.matches;
+		return mqAboveSmall.matches && mqAboveMedium.matches;
 	});
 	
 	return has;

--- a/tests/functional/all.js
+++ b/tests/functional/all.js
@@ -11,5 +11,6 @@ define([
 	"./Switch",
 	"./Button",
 	"./Combobox",
-	"./SwapView"
+	"./SwapView",
+	"./features"
 ]);

--- a/tests/functional/features.html
+++ b/tests/functional/features.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+	<head>
+	<meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+	<meta name="viewport"
+		  content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no"/>
+	<meta name="apple-mobile-web-app-capable" content="yes"/>
+
+	<title>deliteful/features test</title>
+	<style>
+		table {
+			border-collapse: collapse;
+		}
+		td {
+			padding: 2px;
+			border:  1px solid black;
+		}
+	</style>
+	<script src="../../../requirejs/require.js"></script>
+	<script>
+		var ready = false; // set to true when the test page is ready
+		
+		var _has = null;
+		
+		require({
+			baseUrl: "../../.."
+			}, ["deliteful/features", "requirejs-domready/domReady!"],
+			function (has) {
+				_has = {}; // used in tests/functional/features.js
+				function update() {
+					["phone-like-channel", "tablet-like-channel", "desktop-like-channel"].forEach(
+						function (key) {
+							_has[key] = has(key);
+							var res = has(key);
+							tbody.innerHTML += "<tr><td>has(\"" + key + "\")</td><td>" +
+								(res === undefined ? "undefined" : res) + "</td></tr>";
+					});
+				};
+				
+				update();
+				
+				ready = true;
+			});
+	</script>
+</head>
+<body>
+	<h1>deliteful/features results</h1>
+	<table>
+		<tbody id="tbody">
+		</tbody>
+	</table>
+</body>
+</html>

--- a/tests/functional/features.js
+++ b/tests/functional/features.js
@@ -40,7 +40,7 @@ define([
 		"channel flags and breakpoint flags": function () {
 			this.timeout = intern.config.TEST_TIMEOUT;
 			var remote = this.remote;
-			return loadFile(this.remote, "./features.html")
+			return loadFile(remote, "./features.html")
 				.execute("return _has")
 				.then(function (has) {
 					/* jshint maxcomplexity: 17 */

--- a/tests/functional/features.js
+++ b/tests/functional/features.js
@@ -1,0 +1,88 @@
+define([
+	"intern",
+	"intern!object",
+	"intern/dojo/node!leadfoot/helpers/pollUntil",
+	"intern/chai!assert",
+	"require"
+], function (intern, registerSuite, pollUntil, assert, require) {
+	
+	var testChannelFlagsDone = false;
+	
+	var loadFile = function (remote, fileName) {
+		return remote
+			.get(require.toUrl(fileName))
+			.then(pollUntil("return ready ? true : null;", [],
+				intern.config.WAIT_TIMEOUT, intern.config.POLL_INTERVAL));
+	};
+	
+	var checkChannelFlags = function (has, isPhone, isTablet, isDesktop, description) {
+		assert.strictEqual(has["phone-like-channel"], isPhone,
+			"phone-like-channel on " + description);
+		assert.strictEqual(has["tablet-like-channel"], isTablet,
+			"tablet-like-channel on " + description);
+		assert.strictEqual(has["desktop-like-channel"], isDesktop,
+			"desktop-like-channel on " + description);
+		testChannelFlagsDone = true;
+	};
+	var checkChannelFlagsPhone = function (has, description) {
+		checkChannelFlags(has, true, false, false, description);
+	};
+	var checkChannelFlagsTablet = function (has, description) {
+		checkChannelFlags(has, false, true, false, description);
+	};
+	var checkChannelFlagsDesktop = function (has, description) {
+		checkChannelFlags(has, false, false, true, description);
+	};
+	
+	registerSuite({
+		name: "deliteful/features - functional",
+
+		"channel flags and breakpoint flags": function () {
+			this.timeout = intern.config.TEST_TIMEOUT;
+			var remote = this.remote;
+			return loadFile(this.remote, "./features.html")
+				.execute("return _has")
+				.then(function (has) {
+					/* jshint maxcomplexity: 17 */
+					var platform = remote.environmentType.platform ?
+							remote.environmentType.platform.toUpperCase() : null,
+						deviceName = remote.environmentType.deviceName ?
+							remote.environmentType.deviceName.toUpperCase() : null,
+						browserName = remote.environmentType.browserName ?
+							remote.environmentType.browserName.toUpperCase() : null;
+
+					var description = "platform: " + platform + " deviceName: " + deviceName +
+						" browserName: " + browserName;
+					
+					if (platform &&
+						platform.indexOf("WINDOWS") !== -1 ||
+						platform.indexOf("XP") !== -1 ||
+						platform.indexOf("LINUX") !== -1 ||
+						platform.indexOf("OS X") !== -1) {
+						checkChannelFlagsDesktop(has, description);
+					} else if (deviceName) {
+						// Values of deviceName may evolve depending on the configuration
+						// of saucelabs test platforms, and depending on the config files
+						// (tests/intern(.local).js).
+						if (deviceName.indexOf("IPHONE") !== -1 ||
+							deviceName.indexOf("GALAXY S") !== -1 ||
+							deviceName.indexOf("GALAXY NOTE") !== -1 ||
+							deviceName.indexOf("NEXUS 4") !== -1 ||
+							deviceName.indexOf("NEXUS 5") !== -1) {
+							checkChannelFlagsPhone(has, description);
+						} else if (deviceName.indexOf("IPAD") !== -1 ||
+							deviceName.indexOf("NEXUS 7") !== -1 ||
+							deviceName.indexOf("GALAXY TAB") !== -1) {
+							checkChannelFlagsTablet(has, description);
+						}
+					}
+					// Did the test run on a platform such that the testing code above doesn't check
+					// the flags? This assertion allows to detect whether we need to update the
+					// testing code to add new platforms/devices.
+					assert.isTrue(testChannelFlagsDone, "not checked with platform: " +
+						platform + " deviceName: " + deviceName);
+				})
+				.end();
+		}
+	});
+});

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -29,5 +29,6 @@ define([
 	"./ViewStack",
 	"./SwapView",
 	"./ViewIndicator",
-	"./Combobox"
+	"./Combobox",
+	"./channelBreakpoints"
 ]);

--- a/tests/unit/channelBreakpoints.js
+++ b/tests/unit/channelBreakpoints.js
@@ -1,0 +1,45 @@
+define([
+	"intern!object",
+	"intern/chai!assert"
+], function (registerSuite, assert) {
+
+	registerSuite({
+		name: "deliteful/channelBreakpoints",
+		
+		"Default values" : function () {
+			var dfd = this.async();
+
+			require(["deliteful/channelBreakpoints"],
+				dfd.callback(function (channelBreakpoints) {
+					assert.strictEqual(channelBreakpoints.smallScreen, "480px",
+						"default value of smallScreen");
+					assert.strictEqual(channelBreakpoints.mediumScreen, "1024px",
+						"default value of mediumScreen");
+				}));
+		},
+
+		"Custom config" : function () {
+			var configRequire = require.config({
+				context: "configTest",
+				// baseUrl is relative to deliteful/node_modules/intern/
+				baseUrl: "../../..",
+				config: {
+					"deliteful/channelBreakpoints": {
+						smallScreen: "314px",
+						mediumScreen: "514px"
+					}
+				}
+			});
+			
+			var dfd = this.async();
+
+			configRequire(["deliteful/channelBreakpoints"],
+				dfd.callback(function (channelBreakpoints) {
+					assert.strictEqual(channelBreakpoints.smallScreen, "314px",
+						"custom config of smallScreen");
+					assert.strictEqual(channelBreakpoints.mediumScreen, "514px",
+						"custom config of mediumScreen");
+				}));
+		}
+	});
+});


### PR DESCRIPTION
This PR implements #366 and includes:

* Two new multichannel infrastructure modules:
  * https://github.com/AdrianVasiliu/deliteful/blob/channelPolicy-pr/features.js
    * Extends `has()` with channel features (phone-like, tablet-like, and destop-like) computed using CSS media queries based on screen width.
    * Used by multichannel widgets (Combobox for now).
  * https://github.com/AdrianVasiliu/deliteful/blob/channelPolicy-pr/channelBreakpoints.js 
     * Configurable object providing the values of the channel breakpoints.
     * Used by multichannel widgets indirectly via deliteful/features, and used directly by responsive widgets (ResponsiveColumns for now) that want to share the same default values of the breakpoints as multichannel widgets and to allow a global static configuration using `require.config()`.
* Modified Combobox and ResponsiveColumns to leverage the new infrastructure.
* Doc and tests.

