### PR TITLE
Switch: fixing disabled mode

### DIFF
--- a/Switch.js
+++ b/Switch.js
@@ -75,50 +75,46 @@ define([
 		},
 
 		_pointerMoveHandler: function (e) {
-			if (! this.disabled) {
-				var dx = e.clientX - this._curX,
-					cs = window.getComputedStyle(this._pushNode),
-					w = parseInt(cs.width, 10);
-				if (!this._drag && Math.abs(e.clientX - this._startX) > 4) {
-					this._drag = true;
-					$(this._innerNode).removeClass("-d-switch-transition");
-					$(this._pushNode).removeClass("-d-switch-transition");
-					$(this._innerWrapperNode).removeClass("-d-switch-transition");
-				}
-				this._curX = e.clientX;
-				if (this._drag) {
-					// knobWidth and switchWidth are sometimes wrong if computed in 
-					// attachedCallback on Chrome so do it here
-					this._knobWidth = parseInt(window.getComputedStyle(this._knobNode).width, 10);
-					this._switchWidth = parseInt(window.getComputedStyle(this).width, 10);
-					var nw = this.isLeftToRight() ? w + dx : w - dx,
-						max = this.checked ? this._switchWidth : this._switchWidth - this._knobWidth,
-						min = this.checked ? this._knobWidth : 0;
-					nw = Math.max(min, Math.min(max, nw));
-					this._pushNode.style.width = nw + "px";
-				}
-				e.preventDefault();
-				e.stopPropagation();
+			var dx = e.clientX - this._curX,
+				cs = window.getComputedStyle(this._pushNode),
+				w = parseInt(cs.width, 10);
+			if (!this._drag && Math.abs(e.clientX - this._startX) > 4) {
+				this._drag = true;
+				$(this._innerNode).removeClass("-d-switch-transition");
+				$(this._pushNode).removeClass("-d-switch-transition");
+				$(this._innerWrapperNode).removeClass("-d-switch-transition");
 			}
+			this._curX = e.clientX;
+			if (this._drag) {
+				// knobWidth and switchWidth are sometimes wrong if computed in 
+				// attachedCallback on Chrome so do it here
+				this._knobWidth = parseInt(window.getComputedStyle(this._knobNode).width, 10);
+				this._switchWidth = parseInt(window.getComputedStyle(this).width, 10);
+				var nw = this.isLeftToRight() ? w + dx : w - dx,
+					max = this.checked ? this._switchWidth : this._switchWidth - this._knobWidth,
+					min = this.checked ? this._knobWidth : 0;
+				nw = Math.max(min, Math.min(max, nw));
+				this._pushNode.style.width = nw + "px";
+			}
+			e.preventDefault();
+			e.stopPropagation();
 		},
 
 		_pointerUpHandler: function (e) {
-			if (! this.disabled) {
-				var oldCheckedValue = this.checked;
-				if (!this._drag) {
-					this.checked = !this.checked;
-				} else {
-					this._drag = false;
-					var cs = parseInt(window.getComputedStyle(this._pushNode).width, 10);
-					var m = parseInt(window.getComputedStyle(this._pushNode).marginLeft, 10);
-					this.checked = cs + m + this._knobWidth / 2 >= this._switchWidth / 2;
-				}
-				if (this.checked !== oldCheckedValue) {
-					this.emit("change");
-				}
-				e.preventDefault();
-				e.stopPropagation();
+			var oldCheckedValue = this.checked;
+			if (!this._drag) {
+				this.checked = !this.checked;
+			} else {
+				this._drag = false;
+				var cs = parseInt(window.getComputedStyle(this._pushNode).width, 10);
+				var m = parseInt(window.getComputedStyle(this._pushNode).marginLeft, 10);
+				this.checked = cs + m + this._knobWidth / 2 >= this._switchWidth / 2;
 			}
+			if (this.checked !== oldCheckedValue) {
+				this.emit("change");
+			}
+			e.preventDefault();
+			e.stopPropagation();
 		},
 
 		_lostPointerCaptureHandler: function () {

--- a/Switch/themes/Switch_template.less
+++ b/Switch/themes/Switch_template.less
@@ -11,6 +11,9 @@
 		outline:0;
 		.d-switch-focused-styles();
 	}
+	&.d-disabled {
+		opacity: .6;
+	}
 }
 
 // internal classes
@@ -91,7 +94,6 @@
 	-webkit-transition: margin-left 100ms ease-in, width 100ms ease-in;
 	transition: margin-left 100ms ease-in, width 100ms ease-in;
 }
-
 
 .d-switch-width {
 	width: @d-switch-w;

--- a/Switch/themes/bootstrap/Switch.css
+++ b/Switch/themes/bootstrap/Switch.css
@@ -14,6 +14,9 @@
   box-shadow: 0 0 8px rgba(102, 175, 233, 0.6);
   border-color: #66afe9;
 }
+.d-switch.d-disabled {
+  opacity: .6;
+}
 .-d-switch-inner {
   position: absolute;
   width: 30px;

--- a/Switch/themes/holodark/Switch.css
+++ b/Switch/themes/holodark/Switch.css
@@ -13,6 +13,9 @@
   box-shadow: 0 0 8px rgba(102, 175, 233, 0.6);
   border-color: #66afe9;
 }
+.d-switch.d-disabled {
+  opacity: .6;
+}
 .-d-switch-inner {
   position: absolute;
   width: 30px;

--- a/Switch/themes/ios/Switch.css
+++ b/Switch/themes/ios/Switch.css
@@ -14,6 +14,9 @@
   box-shadow: 0 0 8px rgba(102, 175, 233, 0.6);
   border-color: #66afe9;
 }
+.d-switch.d-disabled {
+  opacity: .6;
+}
 .-d-switch-inner {
   position: absolute;
   width: 30px;

--- a/samples/Buttons.html
+++ b/samples/Buttons.html
@@ -72,6 +72,7 @@
 	<p><label><d-checkbox id="cb2" disabled checked="true"></d-checkbox>Option 2</label></p>
 	<p><label>Option 3<d-switch id="sw1"></d-switch></label></p>
 	<p><label>Option 4<d-switch  id="sw2" checked="true" checkedLabel="ON" uncheckedLabel="OFF"></d-switch></label></p>
+	<p><label>Option 5<d-switch  id="sw5" checked="true" disabled checkedLabel="ON" uncheckedLabel="OFF"></d-switch></label></p>
 </fieldset>
 <fieldset class="buttonPanel">
 	<legend>Using label for=</legend>
@@ -82,6 +83,7 @@
 	<p><d-checkbox id="cb4" disabled checked="true"></d-checkbox><label for="cb4">Option 2</label></p>
 	<p><d-switch id="sw3"></d-switch><label for="sw3">Option 3</label></p>
 	<p><d-switch id="sw4" checked="true" checkedLabel="ON" uncheckedLabel="OFF"></d-switch><label for="sw4">option 4</label></p>
+	<p><d-switch id="sw6" checked="true" disabled checkedLabel="ON" uncheckedLabel="OFF"></d-switch><label for="sw6">option 5</label></p>
 </fieldset>
 </div>
 <fieldset>

--- a/tests/functional/Switch.html
+++ b/tests/functional/Switch.html
@@ -9,27 +9,46 @@
 
 	<!-- For testing purposes. Real applications should load the AMD loader directly -->
 	<script type="text/javascript" src="../boilerplate.js"></script>
+	<script type="text/javascript" charset="utf-8">
+		var ready = false;
+		require([
+				"delite/register",
+				"deliteful/Switch",
+				"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
+				"requirejs-domready/domReady!"
+				], function(register){
+					register.parse();
+					ready = true;
+				});
+		
+	</script>
 
 </head>
 <body>
-<h1>d-switch functional test</h1>
-<button id="b1">Start</button>
-<d-switch id="sw1" name="sw1"></d-switch><label for="sw1">Deliteful switch</label><br/>
-<d-switch id="sw2" name="sw2" disabled></d-switch><label for="sw2">Deliteful switch (disabled)</label>
-<button id="b2">End</button>
+	<h1>d-switch functional test</h1>
+	<button id="b1">Start</button>
+	<d-switch id="sw1" name="sw1"></d-switch><label for="sw1">Deliteful switch</label><br/>
+	<d-switch id="sw2" name="sw2" disabled></d-switch><label for="sw2">Deliteful switch (disabled)</label>
+	<button id="b2">End</button>
 
-<form id="form1" action="processForm.html">
-	<fieldset>
-		<p>
-			Unchecked: <d-switch id="sw3" value="1" name="sw3"></d-switch>
-			Checked: <d-switch id="sw4" checked value="2" name="sw4"></d-switch>
-			Disabled: <d-switch id="sw5" checked disabled value="3" name="sw5"></d-switch>
-			readOnly: <d-switch id="sw6" checked readOnly value="4" name="sw6"></d-switch>
-		</p>
-		<input type="checkbox" id="ccb" name="ccb" value="99" >
-		<input type="reset" id="resetB"/>
-		<input type="submit" id="submitB" />
-	</fieldset>
+	<form id="form1" action="processForm.html">
+		<fieldset>
+			<p>
+				Unchecked: <d-switch id="sw3" value="1" name="sw3"></d-switch>
+				Checked: <d-switch id="sw4" checked value="2" name="sw4"></d-switch>
+				Disabled: <d-switch id="sw5" checked disabled value="3" name="sw5"></d-switch>
+				readOnly: <d-switch id="sw6" checked readOnly value="4" name="sw6"></d-switch>
+			</p>
+			<input type="checkbox" id="ccb" name="ccb" value="99" >
+			<input type="reset" id="resetB"/>
+			<input type="submit" id="submitB" />
+		</fieldset>
 
-</form>
+	</form>
+
+	<!-- disabled switches -->
+	<d-switch id="sw71" name="sw71"></d-switch>
+	<d-switch id="sw72" disabled name="sw72"></d-switch>
+	<d-switch id="sw73" disabled="true" name="sw73"></d-switch>
+	<d-switch id="sw74" disabled="false" name="sw74"></d-switch>
 </body>

--- a/tests/functional/Switch.js
+++ b/tests/functional/Switch.js
@@ -147,6 +147,68 @@ define([
 				})
 				.end()
 				;
+		},
+		"Switch with disabled attribute": function () {
+			this.timeout = intern.config.TEST_TIMEOUT;
+			var remote = this.remote;
+			return loadFile(remote, "./Switch.html")
+				
+				// no disabled attribute
+				.execute("return document.getElementById('sw71').checked;")
+				.then(function (value) {
+					assert.isFalse(value, "the switch should be disabled");
+				})
+				.findByCssSelector("#sw71 .-d-switch-knobglass")
+				.click()
+				.sleep(500) // NOTE: waiting for the sliding to happen
+				.execute("return document.getElementById('sw71').checked;")
+				.then(function (value) {
+					assert.isTrue(value, "the switch shoud be enabled this time");
+				})
+				.end()
+
+				// disabled attribute
+				.execute("return document.getElementById('sw72').checked;")
+				.then(function (value) {
+					assert.isFalse(value, "the switch should be disabled");
+				})
+				.findByCssSelector("#sw72 .-d-switch-knobglass")
+				.click()
+				.sleep(500) // NOTE: waiting for the sliding to happen
+				.execute("return document.getElementById('sw72').checked;")
+				.then(function (value) {
+					assert.isFalse(value, "the switch shoud still be disabled");
+				})
+				.end()
+
+				// disabled=true attribute
+				.execute("return document.getElementById('sw73').checked;")
+				.then(function (value) {
+					assert.isFalse(value, "the switch should be disabled");
+				})
+				.findByCssSelector("#sw73 .-d-switch-knobglass")
+				.click()
+				.sleep(500) // NOTE: waiting for the sliding to happen
+				.execute("return document.getElementById('sw73').checked;")
+				.then(function (value) {
+					assert.isFalse(value, "the switch shoud still be disabled");
+				})
+				.end()
+
+				// disabled=false attribute
+				.execute("return document.getElementById('sw74').checked;")
+				.then(function (value) {
+					assert.isFalse(value, "the switch should be disabled");
+				})
+				.findByCssSelector("#sw74 .-d-switch-knobglass")
+				.click()
+				.sleep(500) // NOTE: waiting for the sliding to happen
+				.execute("return document.getElementById('sw74').checked;")
+				.then(function (value) {
+					assert.isTrue(value, "the switch shoud be enabled this time");
+				})
+				.end()
+				;
 		}
 	});
 });


### PR DESCRIPTION
- removed any interaction with the widget when disabled
- changed the styling to differentiate disabled from enabled
- added a test that checks that clicking on the knob doesn't toggle the switch when disabled
 (I should probably add one that tests the sliding as well).

Styling the disabled mode for each theme.
![image](https://cloud.githubusercontent.com/assets/2982512/5837919/b6033330-a183-11e4-8c1f-18beee4e455f.png) 
![image](https://cloud.githubusercontent.com/assets/2982512/5837951/eb5f0cde-a183-11e4-812b-521de58dda22.png) 
![image](https://cloud.githubusercontent.com/assets/2982512/5837961/02d34c18-a184-11e4-9d7b-150075c482a1.png)

build happening [here](https://travis-ci.org/tkrugg/deliteful/builds/47801380)
