### PR TITLE
Adapt doc layout to fix the navigation of ibm-js.github.io

### DIFF
--- a/docs/Button.md
+++ b/docs/Button.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/Button
 ---
 

--- a/docs/Checkbox.md
+++ b/docs/Checkbox.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/Checkbox
 ---
 

--- a/docs/Combobox.md
+++ b/docs/Combobox.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/Combobox
 ---
 

--- a/docs/LinearLayout.md
+++ b/docs/LinearLayout.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/LinearLayout
 ---
 

--- a/docs/ProgressBar.md
+++ b/docs/ProgressBar.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/ProgressBar
 ---
 

--- a/docs/ProgressIndicator.md
+++ b/docs/ProgressIndicator.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/ProgressIndicator
 ---
 

--- a/docs/RadioButton.md
+++ b/docs/RadioButton.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/RadioButton
 ---
 

--- a/docs/ResponsiveColumns.md
+++ b/docs/ResponsiveColumns.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/ResponsiveColumns
 ---
 

--- a/docs/ScrollableContainer.md
+++ b/docs/ScrollableContainer.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/ScrollableContainer
 ---
 

--- a/docs/Select.md
+++ b/docs/Select.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/Select
 ---
 

--- a/docs/SidePane.md
+++ b/docs/SidePane.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/SidePane
 ---
 

--- a/docs/Slider.md
+++ b/docs/Slider.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/Slider
 ---
 

--- a/docs/StarRating.md
+++ b/docs/StarRating.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/StarRating
 ---
 

--- a/docs/Store.md
+++ b/docs/Store.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/Store
 ---
 

--- a/docs/SwapView.md
+++ b/docs/SwapView.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/SwapView
 ---
 

--- a/docs/Switch.md
+++ b/docs/Switch.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/Switch
 ---
 

--- a/docs/Toaster.md
+++ b/docs/Toaster.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/Toaster
 ---
 

--- a/docs/ToggleButton.md
+++ b/docs/ToggleButton.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/ToggleButton
 ---
 

--- a/docs/ViewIndicator.md
+++ b/docs/ViewIndicator.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/ViewIndicator
 ---
 

--- a/docs/ViewStack.md
+++ b/docs/ViewStack.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/ViewStack
 ---
 

--- a/docs/channelBreakpoints.md
+++ b/docs/channelBreakpoints.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/channelBreakpoints
 ---
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/features
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-layout: doc
+layout: docMain
 ---
 
 ## Introduction

--- a/docs/list/List.md
+++ b/docs/list/List.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/list/List
 ---
 

--- a/docs/list/PageableList.md
+++ b/docs/list/PageableList.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: deliteful/list/PageableList
 ---
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: setup
 ---
 

--- a/docs/tutorial/Part1GettingStarted.md
+++ b/docs/tutorial/Part1GettingStarted.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: tutorial
 title: Deliteful Tutorial Part 1
 ---
 

--- a/docs/tutorial/Part2QuickLook.md
+++ b/docs/tutorial/Part2QuickLook.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: tutorial
 title: Deliteful Tutorial Part 2
 ---
 #Deliteful Tutorial (Part 2) - A Quick Look at Deliteful Components

--- a/docs/tutorial/Part3PhotoFeedApp.md
+++ b/docs/tutorial/Part3PhotoFeedApp.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: tutorial
 title: Deliteful Tutorial Part 3
 ---
 #Deliteful Tutorial (Part 3) - Introducing the Photo Feed Application

--- a/docs/tutorial/Part4ListView.md
+++ b/docs/tutorial/Part4ListView.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: tutorial
 title: Deliteful Tutorial Part 4
 ---
 #Deliteful Tutorial (Part 4) - The Photo List View

--- a/docs/tutorial/Part5CustomRenderer.md
+++ b/docs/tutorial/Part5CustomRenderer.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: tutorial
 title: Deliteful Tutorial Part 5
 ---
 #Deliteful Tutorial (Part 5) - Enhancing the List View

--- a/docs/tutorial/Part6DetailsView.md
+++ b/docs/tutorial/Part6DetailsView.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: tutorial
 title: Deliteful Tutorial Part 6
 ---
 #Deliteful Tutorial (Part 6) - Adding a Details View

--- a/docs/tutorial/Part7SettingsView.md
+++ b/docs/tutorial/Part7SettingsView.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: tutorial
 title: Deliteful Tutorial Part 7
 ---
 #Deliteful Tutorial (Part 7) - The Settings View

--- a/docs/tutorial/Part8Build.md
+++ b/docs/tutorial/Part8Build.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: tutorial
 title: Deliteful Tutorial Part 8
 ---
 #Deliteful Tutorial (Part 8) - Building the Application for Production

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,5 +1,5 @@
 ---
-layout: tutorial
+layout: tutorialMain
 ---
 
 The deliteful tutorial guides you, step by step, to build a photo feed viewer based on <a href="https://www.flickr.com/services/api/">Flickr</a> services.


### PR DESCRIPTION
This is to fix the menu of ibm-js.github.io.

If you navigate to http://ibm-js.github.io/deliteful/docs/master/Button.html you can see that the `Docs` item in the menu is not highlighted.