### PR TITLE
startup() calls: remove or replace w/attachedCallback()

### DIFF
--- a/ToasterMessage.js
+++ b/ToasterMessage.js
@@ -417,7 +417,7 @@ define(["dcl/dcl",
 			} else {
 				wrapper.appendChild(this);
 			}
-			this.startup();
+			this.attachedCallback();
 
 			// starting timer
 			if (this.isExpirable()) {

--- a/docs/Button.md
+++ b/docs/Button.md
@@ -40,7 +40,6 @@ See [`delite/Widget`](/delite/docs/master/Widget.md) for full details on how ins
   ], function (register, button) {
      var b = new Button({label: "I am a Button"});
      b.placeAt(document.body);
-     b.startup();
 });
 ```
 

--- a/docs/Checkbox.md
+++ b/docs/Checkbox.md
@@ -59,10 +59,8 @@ src="http://jsfiddle.net/ibmjs/7sxarg93/embedded/result,html,js">
 
      var cb = new Checkbox({checked:true});
      cb.placeAt(document.body);
-     cb.startup();
      cb = new Checkbox({disabled:true, name: "option1"});
      cb.placeAt(document.body);
-     cb.startup();
 });
 ```
 

--- a/docs/Combobox.md
+++ b/docs/Combobox.md
@@ -82,7 +82,6 @@ require(["delite/register", "dstore/Memory", "dstore/Trackable",
     // Create the Combobox
     var Combobox = new Combobox({list: list, selectionMode: "multiple"});
     Combobox.placeAt(document.body);
-    Combobox.startup();
 });
 ```
 
@@ -191,7 +190,6 @@ set for `value` on the `List` instance, for example:
     // Create the Combobox
     var combobox = new Combobox({list: list, ...});
     combobox.placeAt(document.body);
-    combobox.startup();
 ```
 
 or in markup:

--- a/docs/LinearLayout.md
+++ b/docs/LinearLayout.md
@@ -53,7 +53,6 @@ require(["deliteful/LinearLayout", "requirejs-domready/domReady!"], function (Li
   layout.addChild(centerChild);
   layout.addChild(rightChild);
   layout.placeAt(document.body);
-  layout.startup();
 });
 ```
 

--- a/docs/ProgressBar.md
+++ b/docs/ProgressBar.md
@@ -57,7 +57,6 @@ See [`delite/Widget`](/delite/docs/master/Widget.md) for full details on how ins
 
      var pb = new ProgressBar({max:100, value: 0});
      pb.placeAt(document.body);
-     pb.startup();
      pb.value = 20;
 });
 ```

--- a/docs/ProgressIndicator.md
+++ b/docs/ProgressIndicator.md
@@ -62,7 +62,6 @@ ProgressIndicator must be active to become visible and start its animation.
 
      var pi = new ProgressIndicator({active: true});
      pi.placeAt(document.body);
-     pi.startup();
 
      register.parse();
      //do some other tasks (load data...)

--- a/docs/RadioButton.md
+++ b/docs/RadioButton.md
@@ -55,13 +55,10 @@ allowfullscreen="allowfullscreen" frameborder="0">
 
      var sw = new RadioButton({checked:true, name: "category", value: "SUV"});
      sw.placeAt(document.body);
-     sw.startup();
      sw = new RadioButton({name: "category", value: "Sport"});
      sw.placeAt(document.body);
-     sw.startup();
      sw = new RadioButton({name: "category", value: "Executive"});
      sw.placeAt(document.body);
-     sw.startup();
 });
 ```
 

--- a/docs/ResponsiveColumns.md
+++ b/docs/ResponsiveColumns.md
@@ -54,7 +54,6 @@ require([
 	"requirejs-domready/domReady!"
 ], function(ResponsiveColumns){
 	rc = new ResponsiveColumns();
-	window.document.body.appendChild(rc, 1);
 	rc.breakpoints = "{'small': '500px', 'medium': '900px', 'large': ''}";
 	var child = document.createElement("div");
 	child.setAttribute("layout", "{'small': '100%', 'medium': '200px', 'large': '10%'}");
@@ -68,7 +67,7 @@ require([
 	child.innerHTML = "Child 3";
 	child.setAttribute("layout", "{'small': 'hidden', 'medium': 'hidden', 'large': '60%'}");
 	rc.addChild(child);
-	rc.startup();
+	rc.placeAt(document.body);
 });
 ```
 

--- a/docs/ScrollableContainer.md
+++ b/docs/ScrollableContainer.md
@@ -68,8 +68,7 @@ require([
 
     var sc = new ScrollableContainer({scrollDirection: "both"});
     sc.placeAt(document.body);
-    sc.startup();
-    
+
     // add content to the scrollable container:
     var child = document.createElement("div");
     sc.addChild(child);
@@ -178,7 +177,6 @@ define(["delite/register", "deliteful/ScrollableContainer", ...],
           var scrollableNode =
             // or your own scrollable widget
             new ScrollableContainer(...);
-          scrollableNode.startup();
           ...
           this.appendChild(scrollableNode);
           // If needed, add other scrollable widgets as child elements

--- a/docs/Select.md
+++ b/docs/Select.md
@@ -68,7 +68,6 @@ require(["delite/register", "dstore/Memory", "dstore/Trackable",
     store.add({text: "Option 1", value: "1"});
     ...
     select.placeAt(document.body);
-    select.startup();
 });
 ```
 

--- a/docs/SidePane.md
+++ b/docs/SidePane.md
@@ -50,7 +50,6 @@ require(["delite/register", "deliteful/SidePane", "requirejs-domready/domReady!"
 require(["deliteful/SidePane", "requirejs-domready/domReady!"], function (SidePane) {
   var sp = new SidePane({mode: "overlay"});
   sp.placeAt(document.body);
-  sp.startup();
 });
 ```
 

--- a/docs/Slider.md
+++ b/docs/Slider.md
@@ -83,7 +83,6 @@ buttons.
   ], function (register, Slider) {
     var slider = new Slider({value:10, step:5, min:10, max:50});
     slider.placeAt(document.body);
-    slider.startup();  
 });
 ```
 

--- a/docs/StarRating.md
+++ b/docs/StarRating.md
@@ -41,7 +41,6 @@ See [`delite/Widget`](/delite/docs/master/Widget.md) for full details on how ins
 require(["deliteful/StarRating", "requirejs-domready/domReady!"], function (StarRating) {
   var starRating = new StarRating({max: 7, value: 3.5, editHalfValues: true});
   starRating.placeAt(document.body);
-  starRating.startup();
 });
 ```
 

--- a/docs/SwapView.md
+++ b/docs/SwapView.md
@@ -59,7 +59,6 @@ require(["deliteful/SwapView", "requirejs-domready/domReady!"], function (SwapVi
   sv.addChild(child2);
   sv.addChild(child3);
   sv.placeAt(document.body);
-  sv.startup();
 });
 ```
 

--- a/docs/Switch.md
+++ b/docs/Switch.md
@@ -47,10 +47,9 @@ See [`delite/Widget`](/delite/docs/master/Widget.md) for full details on how ins
 
      var sw = new Switch({checked:true});
      sw.placeAt(document.body);
-     sw.startup();
+
      sw = new Switch({checkedLabel: "ON", uncheckedLabel: "OFF", name: "bluetooth"});
      sw.placeAt(document.body);
-     sw.startup();
 });
 ```
 

--- a/docs/ToggleButton.md
+++ b/docs/ToggleButton.md
@@ -56,10 +56,9 @@ src="http://jsfiddle.net/ibmjs/at8z7abL/embedded/result,js,html">
          label: "Off"
      });
      tb.placeAt(document.body);
-     tb.startup();
+
      tb = new ToggleButton({checked: true, label: "WiFi"});
      tb.placeAt(document.body);
-     tb.startup();
 });
 ```
 

--- a/docs/ViewIndicator.md
+++ b/docs/ViewIndicator.md
@@ -59,10 +59,9 @@ function (SwapView, ViewIndicator) {
   sv.addChild(child2);
   sv.addChild(child3);
   sv.placeAt(document.body);
-  sv.startup();
+
   var vi = new ViewIndicator({viewstack: sv, style: "width:100%"});
   vi.placeAt(document.body);
-  vi.startup();
 });
 ```
 

--- a/docs/ViewStack.md
+++ b/docs/ViewStack.md
@@ -59,7 +59,6 @@ require(["deliteful/ViewStack", "requirejs-domready/domReady!"], function (ViewS
   vs.addChild(child2);
   vs.addChild(child3);
   vs.placeAt(document.body);
-  vs.startup();
 });
 ```
 

--- a/docs/list/List.md
+++ b/docs/list/List.md
@@ -90,7 +90,6 @@ require(["dstore/Memory", "delite/list/List", "requirejs-domready/domReady!"], f
 	// as the item category.
 	var list = new List({store: dataStore, righttextAttr: "sales", categoryAttr: "region"});
 	list.placeAt(document.body);
-	list.startup();
 });
 ```
 
@@ -166,7 +165,6 @@ require([
 		list.store.add({title: "first item"});
 		...
 		list.placeAt(document.body);
-		list.startup();
 });
 ```
 

--- a/docs/list/PageableList.md
+++ b/docs/list/PageableList.md
@@ -70,7 +70,6 @@ require(["dstore/Memory", "delite/list/PageableList", "requirejs-domready/domRea
   var list = new PageableList({store: dataStore, righttextAttr: "sales", categoryAttr: "region"});
   list.style.height = "100%";
   list.placeAt(document.body);
-  list.startup();
 });
 ```
 
@@ -105,8 +104,7 @@ Here is an example of setting a pageLength of 100 items:
 			var pageableList = new PageableList();
 			pageableList.pageLength = 100;
 			...
-			this.ownerDocument.body.appendChild(pageableList);
-			pageableList.startup();
+			pageableList.placeAt(document.body);
 		});
 ```
 

--- a/list/List.js
+++ b/list/List.js
@@ -542,7 +542,7 @@ define([
 				} else {
 					this.appendChild(this._loadingPanel);
 				}
-				this._loadingPanel.startup();
+				this._loadingPanel.attachedCallback();
 			}
 		},
 
@@ -610,9 +610,7 @@ define([
 			}
 			// start renderers
 			this.findCustomElements(this).forEach(function (w) {
-				if (w.startup) {
-					w.startup();
-				}
+				w.attachedCallback();
 			});
 		},
 
@@ -663,7 +661,7 @@ define([
 				if (spec.addCategoryAfter) {
 					var categoryRenderer = this._createCategoryRenderer(spec.nodeRef.item);
 					this.insertBefore(categoryRenderer, spec.nodeRef);
-					categoryRenderer.startup();
+					categoryRenderer.attachedCallback();
 				}
 			} else {
 				this.appendChild(renderer);
@@ -671,9 +669,9 @@ define([
 			if (spec.addCategoryBefore) {
 				categoryRenderer = this._createCategoryRenderer(renderer.item);
 				this.insertBefore(categoryRenderer, renderer);
-				categoryRenderer.startup();
+				categoryRenderer.attachedCallback();
 			}
-			renderer.startup();
+			renderer.attachedCallback();
 		},
 
 		/**

--- a/list/PageableList.js
+++ b/list/PageableList.js
@@ -646,7 +646,6 @@ define([
 			});
 			this._nextPageLoader.deliver();
 			this._nextPageLoader.placeAt(this);
-			this._nextPageLoader.startup();
 		},
 
 		/**
@@ -674,7 +673,6 @@ define([
 			});
 			this._previousPageLoader.deliver();
 			this._previousPageLoader.placeAt(this, "first");
-			this._previousPageLoader.startup();
 		},
 
 		//////////// List methods overriding ///////////////////////////////////////

--- a/samples/Toaster.html
+++ b/samples/Toaster.html
@@ -26,7 +26,6 @@
 		], function (ToasterMessage, Toaster) {
 			window.toaster = new Toaster({placementClass: "d-toaster-placement-tr"});
 			toaster.placeAt("body");
-			toaster.startup();
 			var timeout = 0;
 			var messages = [
 				new ToasterMessage({ message: "This will fade on its own"}),

--- a/samples/list/StoreMap-mapping.html
+++ b/samples/list/StoreMap-mapping.html
@@ -37,8 +37,7 @@
 			list.store.add({title: "third item"});
 			list.store.add({title: "fourth item"});
 			list.store.add({title: "fifth item"});
-			document.body.appendChild(list);
-			list.startup();
+			list.placeAt(document.body);
 
 			document.body.style.display = "";
 		});

--- a/samples/list/categorized.html
+++ b/samples/list/categorized.html
@@ -35,8 +35,7 @@
 			list.store.add({label: "third item", category: "Category A"});
 			list.store.add({label: "fourth item", category: "Category B"});
 			list.store.add({label: "fifth item", category: "Category B"});
-			document.body.appendChild(list);
-			list.startup();
+			list.placeAt(document.body);
 
 			document.body.style.display = "";
 		});

--- a/samples/list/customCategoryRenderer.html
+++ b/samples/list/customCategoryRenderer.html
@@ -46,8 +46,7 @@
 			list.store.add({label: "Cabbage", cat: "Vegetable"});
 			list.store.add({label: "Kale", cat: "Vegetable"});
 			list.store.add({label: "Lettuce", cat: "Vegetable"});
-			document.body.appendChild(list);
-			list.startup();
+			list.placeAt(document.body);
 
 			document.body.style.display = "";
 		});

--- a/samples/list/customItemRenderer.html
+++ b/samples/list/customItemRenderer.html
@@ -41,8 +41,7 @@
 			list.store.add({title: "Practical Dojo Projects (Expert's Voice in Web Development)", isbn: "1430210664"});
 			list.store.add({title: "The Dojo Toolkit: Visual QuickStart Guide", isbn: "0321605128"});
 			list.store.add({title: "Mastering Dojo: JavaScript and Ajax Tools for Great Web Experiences", isbn: "1934356115"});
-			document.body.appendChild(list);
-			list.startup();
+			list.placeAt(document.body);
 
 			document.body.style.display = "";
 		});

--- a/samples/list/forms.html
+++ b/samples/list/forms.html
@@ -71,8 +71,7 @@
 			list.store.add({firstName: "Paul", lastName: "Smith", dateOfBirth: "11/10/1982"});
 			list.store.add({firstName: "Anthony", lastName: "Platters", dateOfBirth: "08/15/1964"});
 			list.store.add({firstName: "Lydia", lastName: "Melrose", dateOfBirth: "07/03/1982"});
-			document.body.appendChild(list);
-			list.startup();
+			list.placeAt(document.body);
 			list.setAttribute("aria-readonly", "false");
 
 			document.body.style.display = "";

--- a/samples/list/header-list-footer.html
+++ b/samples/list/header-list-footer.html
@@ -31,7 +31,6 @@
 			for (var i = 0; i < 50; i++) {
 				list.store.add({label: "Item #" + i});
 			}
-			list.startup();
 			document.body.style.display = "";
 		});
 	</script>

--- a/samples/list/inputElements.html
+++ b/samples/list/inputElements.html
@@ -65,9 +65,8 @@
 			list.store.add({label: "Login", elementTag: "INPUT", elementAttrs: {type: "text"}});
 			list.store.add({label: "Apex ringtone", elementTag: "INPUT", elementAttrs: {type: "radio", name: "ringtone", value: "apex", checked: true}});
 			list.store.add({label: "Beacon ringtone", elementTag: "INPUT", elementAttrs: {type: "radio", name: "ringtone", value: "beacon"}});
-			document.body.appendChild(list);
-			list.startup();
 			list.setAttribute("aria-readonly", "false");
+			list.placeAt(document.body);
 
 			document.body.style.display = "";
 		});

--- a/samples/list/itemToRenderItem.html
+++ b/samples/list/itemToRenderItem.html
@@ -39,8 +39,7 @@
 			list.store.add({title: "third item"});
 			list.store.add({title: "fourth item"});
 			list.store.add({title: "fifth item"});
-			document.body.appendChild(list);
-			list.startup();
+			list.placeAt(document.body);
 
 			document.body.style.display = "";
 		});

--- a/samples/list/listBox-multipleSelection-markBefore.html
+++ b/samples/list/listBox-multipleSelection-markBefore.html
@@ -46,8 +46,7 @@
 					console.innerHTML = "Click to select an item.";
 				}
 			}.bind(list));
-			document.body.appendChild(list);
-			list.startup();
+			list.placeAt(document.body);
 
 			document.body.style.display = "";
 		});

--- a/samples/list/listBox-singleSelection-markAfter.html
+++ b/samples/list/listBox-singleSelection-markAfter.html
@@ -45,8 +45,7 @@
 					console.innerHTML = "Click to select an item.";
 				}
 			});
-			document.body.appendChild(list);
-			list.startup();
+			list.placeAt(document.body);
 
 			document.body.style.display = "";
 		});

--- a/samples/list/pageable_customLoadMessages.html
+++ b/samples/list/pageable_customLoadMessages.html
@@ -35,8 +35,7 @@
 			list.maxPages = 2;
 			list.loadPreviousMessage = "Load previous data (${pageLength} entries)";
 			list.loadNextMessage = "Load next data (${pageLength} entries)";
-			document.body.appendChild(list);
-			list.startup();
+			list.placeAt(document.body);
 
 			document.body.style.display = "";
 		});

--- a/tests/functional/Combobox-prog.html
+++ b/tests/functional/Combobox-prog.html
@@ -56,16 +56,14 @@
 			// default selectionMode: "single"
 			combo1 = combobox; // for debug
 			combobox.name = combobox.id; // for Form
-			combobox.startup();
-			
+
 			list = new List({store: dataStoreWithValue, valueAttr: "myValue", 
 				righttextAttr: "sales", categoryAttr: "region"});
 			combobox = new Combobox({list: list, id: "combo-single-value"}).placeAt("combo-single-value", "replace");
 			// default selectionMode: "single"
 			combo1value = combobox; // for debug
 			combobox.name = combobox.id; // for Form
-			combobox.startup();
-			
+
 			list = new List({store: dataStore, righttextAttr: "sales", categoryAttr: "region"});
 			combo2 = combobox; // for debug
 			combobox = new Combobox({autoFilter: true, list: list, id: "combo-single-autoFilter"}).
@@ -73,8 +71,7 @@
 			combo2 = combobox; // for debug
 			// default selectionMode: "single"
 			combobox.name = combobox.id; // for Form
-			combobox.startup();
-			
+
 			startsWith.on("change", function () {
 				combo2.filterMode = "startsWith";
 			});
@@ -94,16 +91,14 @@
 				placeAt("combo-multiple", "replace");
 			combo3 = combobox; // for debug
 			combobox.name = combobox.id; // for Form
-			combobox.startup();
-			
+
 			list = new List({store: dataStoreWithValue, valueAttr: "myValue", 
 				righttextAttr: "sales", categoryAttr: "region"});
 			combobox = new Combobox({list: list, selectionMode: "multiple", id: "combo-multiple-value"}).
 				placeAt("combo-multiple-value", "replace");
 			combo3value = combobox; // for debug
 			combobox.name = combobox.id; // for Form
-			combobox.startup();
-			
+
 			// Now the same but disabled
 			// 
 			list = new List({store: dataStore, righttextAttr: "sales", categoryAttr: "region"});
@@ -112,8 +107,7 @@
 			// default selectionMode: "single"
 			combo4 = combobox; // for debug
 			combobox.name = combobox.id; // for Form
-			combobox.startup();
-			
+
 			list = new List({store: dataStore, righttextAttr: "sales", categoryAttr: "region"});
 			combobox = new Combobox({autoFilter: true, list: list, 
 				disabled: true, id: "combo-single-autoFilter-disabled"}).
@@ -121,16 +115,14 @@
 			// default selectionMode: "single"
 			combo5 = combobox; // for debug
 			combobox.name = combobox.id; // for Form
-			combobox.startup();
-			
+
 			list = new List({store: dataStore, righttextAttr: "sales", categoryAttr: "region"});
 			combobox = new Combobox({list: list, selectionMode: "multiple", 
 				id: "combo-multiple-disabled", disabled: true}).
 				placeAt("combo-multiple-disabled", "replace");
 			combo6 = combobox; // for debug
 			combobox.name = combobox.id; // for Form
-			combobox.startup();
-			
+
 			// Combobox in single mode with custom initial selection
 			list = new List({store: dataStore, righttextAttr: "sales", categoryAttr: "region"});
 			combobox =
@@ -140,7 +132,6 @@
 			// default selectionMode: "single"
 			combo5customSelSingle = combobox; // for debug
 			combobox.name = combobox.id; // for Form
-			combobox.startup();
 			combobox.deliver();
 			// Configure with its fourth option initially selected
 			combobox.list.selectedItem = combobox.list.store.data[3];
@@ -153,7 +144,6 @@
 					placeAt("combo-custom-sel-multiple", "replace");
 			combo5customSelMultiple = combobox; // for debug
 			combobox.name = combobox.id; // for Form
-			combobox.startup();
 			combobox.deliver();
 			// Configure with its second and fourth options initially selected
 			combobox.list.selectedItems = [combobox.list.store.data[1], combobox.list.store.data[3]];
@@ -168,7 +158,6 @@
 			// default selectionMode: "single"
 			combo5readonly = combobox; // for debug
 			combobox.name = combobox.id; // for Form
-			combobox.startup();
 			
 			list = new List({store: dataStore, righttextAttr: "sales", categoryAttr: "region"});
 			combobox = new Combobox({list: list, dir: "rtl", id: "combo-single"}).
@@ -176,7 +165,6 @@
 			// default selectionMode: "single"
 			combo7 = combobox; // for debug
 			combobox.name = combobox.id; // for Form
-			combobox.startup();
 			
 			// Using the default instance of List created by Combobox
 			combobox = new Combobox({id: "combo-single-default-list"});
@@ -184,7 +172,6 @@
 			combobox.list.store = dataStore;
 			combobox.placeAt("combo-single-default-list", "replace");
 			combobox.name = combobox.id; // for Form
-			combobox.startup();
 		});
 	</script>
 	<style>

--- a/tests/functional/Select.html
+++ b/tests/functional/Select.html
@@ -112,7 +112,6 @@
 			
 			var createSelect = function (selectDiv, min, max, defaultStore) {
 				var select = new Select({id: selectDiv.id}).placeAt(selectDiv, "replace");
-				select.startup();
 				initSelect(select, min, max, defaultStore);
 			};
 				

--- a/tests/functional/StarRating-form.html
+++ b/tests/functional/StarRating-form.html
@@ -22,7 +22,6 @@
 				value: 4,
 				name: "star4"
 			}).placeAt("star4", 'replace');
-			rating.startup();
 
 			rating = new StarRating({
 				id: "starrating5",
@@ -31,7 +30,6 @@
 				readOnly: true,
 				name: "star5"
 			}).placeAt("star5", 'replace');
-			rating.startup();
 
 			rating = new StarRating({
 				id: "starrating6",
@@ -40,7 +38,6 @@
 				disabled: true,
 				name: "star6"
 			}).placeAt("star6", 'replace');
-			rating.startup();
 
 			// Set global variable to signal that the test page is ready
 			ready = true;

--- a/tests/functional/StarRating.html
+++ b/tests/functional/StarRating.html
@@ -45,21 +45,18 @@
 			document.getElementById("editablestar6value").innerHTML = "Rating is " + rating.value +
 			(rating.value === 1 ? " star" : " stars");
 		});
-		rating.startup();
 
 		var rating2 = new StarRating({
 			id: "secondtabindexstar",
 			tabIndex: 2
 		}).placeAt("secondtabindexstar", "replace");
 		rating2.setAttribute("aria-labelledby", "secondtabindexstar-label");
-		rating2.startup();
 
 		rating2 = new StarRating({
 			id: "secondnotabindexstar",
 			tabIndex: -1
 		}).placeAt("secondnotabindexstar", "replace");
 		rating2.setAttribute("aria-labelledby", "secondnotabindexstar-label");
-		rating2.startup();
 
 		// Set global variable to signal that the test page is ready
 		ready = true;

--- a/tests/functional/Toaster.html
+++ b/tests/functional/Toaster.html
@@ -44,7 +44,6 @@
 					// Create Toaster widget pragmatically
 					toast = new Toaster({id: "default"});
 					toast.placeAt("container");
-					toast.startup();
 					var counter = 0;
 
 					// helpers

--- a/tests/functional/list/list-cust-1.html
+++ b/tests/functional/list/list-cust-1.html
@@ -30,7 +30,7 @@
 			list.store = new (Memory.createSubclass([Trackable], {}))();
 			list.style.height = "200px";
 			document.getElementById("listPlaceholder").appendChild(list);
-			list.startup();
+			list.attachedCallback();
   			for (var i = 0; i < 40; i++) {
 				list.store.addSync({});
 			}

--- a/tests/functional/list/list-cust-2.html
+++ b/tests/functional/list/list-cust-2.html
@@ -48,7 +48,7 @@
 			list.store.addSync({title: "The Dojo Toolkit: Visual QuickStart Guide", isbn: "0321605128", bookstore: "FNAC"});
 			list.store.addSync({title: "Mastering Dojo: JavaScript and Ajax Tools for Great Web Experiences", isbn: "1934356115", bookstore: "FNAC"});
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			ready = true;
 		});
 	</script>

--- a/tests/functional/list/list-prog-1.html
+++ b/tests/functional/list/list-prog-1.html
@@ -27,7 +27,7 @@
 				list.store.addSync({label: "Programmatic item of order " + i, righttext: list.id});
 			}
 			document.getElementById("listPlaceholder").appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			ready = true;
 		});
 	</script>

--- a/tests/functional/list/list-prog-2.html
+++ b/tests/functional/list/list-prog-2.html
@@ -24,7 +24,7 @@
 			list.style.height = "200px";
 			list.store = new (Memory.createSubclass([Trackable], {}))();
 			document.getElementById("listPlaceholder").appendChild(list);
-			list.startup();
+			list.attachedCallback();
   			for (var i = 0; i < 100; i++) {
 				list.store.addSync({label: "Programmatic item of order " + i, righttext: list.id});
 			}

--- a/tests/functional/list/list-prog-3.html
+++ b/tests/functional/list/list-prog-3.html
@@ -28,7 +28,7 @@
 				list.store.addSync({label: "Programmatic item of order " + i});
 			}
 			document.getElementById("listPlaceholder").appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			ready = true;
 		});
 	</script>

--- a/tests/functional/list/list-prog-4.html
+++ b/tests/functional/list/list-prog-4.html
@@ -25,7 +25,7 @@
 			var M = MemoryStore.createSubclass([Trackable], {});
 			list.store = new M({data: [], idProperty: "label"});
 			document.getElementById("listPlaceholder").appendChild(list);
-			list.startup();
+			list.attachedCallback();
   			for (var i = 0; i < 100; i++) {
 				list.store.addSync({label: "Programmatic item of order " + i});
 			}

--- a/tests/functional/list/list-prog-5.html
+++ b/tests/functional/list/list-prog-5.html
@@ -66,7 +66,7 @@
 			};
 			list.store = createStore(100, 500);
 			document.getElementById("listPlaceholder").appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			for (var i = 0; i < 100; i++) {
 				list.store.addSync({id: 'ref' + i, text: 'this is list item ' + i});
 			}

--- a/tests/functional/list/listbox-prog-1.html
+++ b/tests/functional/list/listbox-prog-1.html
@@ -28,7 +28,7 @@
 				list.store.add({label: "Programmatic item of order " + i, righttext: list.id});
 			}
 			document.getElementById("listPlaceholder").appendChild(list);
-			list.startup();
+			list.attachedCallback();
 
 			ready = true;
 		});

--- a/tests/functional/list/pageable-prog-1.html
+++ b/tests/functional/list/pageable-prog-1.html
@@ -28,7 +28,7 @@
 				list.store.add({label: "Programmatic item of order " + i});
 			}
 			document.getElementById("listPlaceholder").appendChild(list);
-			list.startup();
+			list.attachedCallback();
 
 			ready = true;
 		});

--- a/tests/functional/list/pageable-prog-2.html
+++ b/tests/functional/list/pageable-prog-2.html
@@ -29,7 +29,7 @@
 				list.store.add({label: "Programmatic item of order " + i, category: "Category " + Math.floor(i / 10)});
 			}
 			document.getElementById("listPlaceholder").appendChild(list);
-			list.startup();
+			list.attachedCallback();
 
 			ready = true;
 		});

--- a/tests/functional/list/pageable-prog-3.html
+++ b/tests/functional/list/pageable-prog-3.html
@@ -28,7 +28,7 @@
 				list.store.add({label: "Programmatic item of order " + i, id: i});
 			}
 			document.getElementById("listPlaceholder").appendChild(list);
-			list.startup();
+			list.attachedCallback();
 
 			document.getElementById("remove").onclick = function () {
 				var inp = document.getElementById("itemIndex");

--- a/tests/functional/list/pageable-prog-4.html
+++ b/tests/functional/list/pageable-prog-4.html
@@ -46,7 +46,7 @@
 				list.store.add({label: "Programmatic item of order " + i, id: i});
 			}
 			document.getElementById("listPlaceholder").appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			var latencyIF = document.getElementById("latency");
 			latencyIF.onchange = function () {
 				list.store.latency = latencyIF.valueAsNumber;

--- a/tests/functional/list/pageable-prog-5.html
+++ b/tests/functional/list/pageable-prog-5.html
@@ -46,7 +46,7 @@
 				list.store.add({label: "Programmatic item of order " + i, id: i});
 			}
 			document.getElementById("listPlaceholder").appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			var latencyIF = document.getElementById("latency");
 			latencyIF.onchange = function () {
 				list.store.latency = latencyIF.valueAsNumber;

--- a/tests/functional/list/pageable-prog-6.html
+++ b/tests/functional/list/pageable-prog-6.html
@@ -48,7 +48,7 @@
 				list.store.add({label: "Programmatic item of order " + i, id: i});
 			}
 			document.getElementById("listPlaceholder").appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			var latencyIF = document.getElementById("latency");
 			latencyIF.onchange = function () {
 				list.store.latency = latencyIF.valueAsNumber;

--- a/tests/functional/list/pageable-prog-7.html
+++ b/tests/functional/list/pageable-prog-7.html
@@ -43,7 +43,7 @@
 				list.store.add({label: "Programmatic item of order " + i, category: "Category " + Math.floor(i / 10)});
 			}
 			document.getElementById("listPlaceholder").appendChild(list);
-			list.startup();
+			list.attachedCallback();
 
 			ready = true;
 		});

--- a/tests/functional/list/pageable-prog-8.html
+++ b/tests/functional/list/pageable-prog-8.html
@@ -29,7 +29,7 @@
 				list.store.add({label: "Programmatic item of order " + i});
 			}
 			document.getElementById("listPlaceholder").appendChild(list);
-			list.startup();
+			list.attachedCallback();
 
 			ready = true;
 		});

--- a/tests/functional/slider/slider-prg.html
+++ b/tests/functional/slider/slider-prg.html
@@ -37,7 +37,7 @@
 					slider.value = singleSliderPrg[i][1];
 				}
 				document.getElementById(slider.id + "_ph").appendChild(slider);
-				slider.startup();
+				slider.attachedCallback();
 			}
 			// read value from d-slider elements and set to span.innerHTML for intern functional test suite.
 			var nodeList = document.querySelectorAll("d-slider");

--- a/tests/unit/Button.js
+++ b/tests/unit/Button.js
@@ -83,16 +83,16 @@ define([
 			document.body.appendChild(container);
 			var b = new Button({id: "b1", label: "b1"});
 			container.appendChild(b);
-			b.startup();
+			b.attachedCallback();
 			b = new Button({id: "b2", value: "foo", label: "b2"});
 			container.appendChild(b);
-			b.startup();
+			b.attachedCallback();
 			b = new Button({id: "b3", label: "b3", iconClass: "ic1"});
 			container.appendChild(b);
-			b.startup();
+			b.attachedCallback();
 			b = new Button({id: "b4", label: "on", iconClass: "ic1"});
 			container.appendChild(b);
-			b.startup();
+			b.attachedCallback();
 		}
 	};
 	dcl.mix(suite, commonSuite);

--- a/tests/unit/Checkbox.js
+++ b/tests/unit/Checkbox.js
@@ -53,10 +53,10 @@ define([
 			document.body.appendChild(container);
 			var cb = new Checkbox({id: "cb1"});
 			container.appendChild(cb);
-			cb.startup();
+			cb.attachedCallback();
 			cb = new Checkbox({id: "cb2", value: "foo"});
 			container.appendChild(cb);
-			cb.startup();
+			cb.attachedCallback();
 			var lbl4 = document.createElement("label");
 			lbl4.id = "lbl4";
 			lbl4.setAttribute("for", "cb3");
@@ -64,7 +64,7 @@ define([
 			container.appendChild(lbl4);
 			cb = new Checkbox({id: "cb3", checked: true});
 			container.appendChild(cb);
-			cb.startup();
+			cb.attachedCallback();
 		}
 	};
 	dcl.mix(progSuite, suite);

--- a/tests/unit/Combobox.js
+++ b/tests/unit/Combobox.js
@@ -91,7 +91,7 @@ define([
 		var combo = new Combobox({ id: id, selectionMode: selectionMode });
 		initCombobox(combo, trackable);
 		container.appendChild(combo);
-		combo.startup();
+		combo.attachedCallback();
 		return combo;
 	};
 
@@ -99,7 +99,7 @@ define([
 		var combo = new MyCombobox({ id: id });
 		initCombobox(combo, trackable);
 		container.appendChild(combo);
-		combo.startup();
+		combo.attachedCallback();
 		return combo;
 	};
 

--- a/tests/unit/ProgressBar.js
+++ b/tests/unit/ProgressBar.js
@@ -12,7 +12,7 @@ define([
 			progressBar = new ProgressBar();
 			progressBar.lang = "en-US";
 			document.body.appendChild(progressBar);
-			progressBar.startup();
+			progressBar.attachedCallback();
 			progressBar.deliver(); //todo: remove when the initialization of properties will be synchronous.
 		},
 		"Default values and state": function () {
@@ -155,7 +155,7 @@ define([
 		"valid init value": function () {
 			var pb = new ProgressBar({value: 10, max: 100});
 			document.body.appendChild(pb);
-			pb.startup();
+			pb.attachedCallback();
 			pb.deliver();//todo: remove when the initialization of properties will be synchronous.
 			assert.strictEqual(10, pb.value);
 			assert.strictEqual(100, pb.max);
@@ -164,7 +164,7 @@ define([
 		"Invalid init value": function () {
 			var pb = new ProgressBar({value: -10, max: -9});
 			document.body.appendChild(pb);
-			pb.startup();
+			pb.attachedCallback();
 			pb.deliver();//todo: remove when the initialization of properties will be synchronous.
 			var value = pb.value, max = pb.max;
 			assert.strictEqual(0, value);

--- a/tests/unit/ProgressIndicator.js
+++ b/tests/unit/ProgressIndicator.js
@@ -17,7 +17,7 @@ define([
 		setup: function () {
 			progressIndicator = new ProgressIndicator();
 			document.body.appendChild(progressIndicator);
-			progressIndicator.startup();
+			progressIndicator.attachedCallback();
 		},
 		"Default values and state": function () {
 			//public attribute:active

--- a/tests/unit/RadioButton.js
+++ b/tests/unit/RadioButton.js
@@ -159,10 +159,10 @@ define([
 			
 			var rb = new RadioButton({id: "rb1", value: "rb1", name: "choice"});
 			form.appendChild(rb);
-			rb.startup();
+			rb.attachedCallback();
 			rb = new RadioButton({id: "rb2", value: "rb2", checked: true, name: "choice"});
 			form.appendChild(rb);
-			rb.startup();
+			rb.attachedCallback();
 			var lbl4 = document.createElement("label");
 			lbl4.id = "lbl4";
 			lbl4.setAttribute("for", "rb3");
@@ -170,10 +170,10 @@ define([
 			container.appendChild(lbl4);
 			rb = new RadioButton({id: "rb3", value: "rb3", name: "choice"});
 			form.appendChild(rb);
-			rb.startup();
+			rb.attachedCallback();
 			rb = new RadioButton({id: "rb4"});
 			container.appendChild(rb);
-			rb.startup();
+			rb.attachedCallback();
 		}
 	};
 	dcl.mix(progSuite, suite);

--- a/tests/unit/ResponsiveColumns.js
+++ b/tests/unit/ResponsiveColumns.js
@@ -62,7 +62,7 @@ define([
 			child.innerHTML = "Child 3";
 			child.setAttribute("layout", "{'small': 'hidden', 'medium': 'hidden', 'large': '60%'}");
 			container.addChild(child);
-			container.startup();
+			container.attachedCallback();
 		},
 
 		"Media Query Test": function () {

--- a/tests/unit/ScrollableContainer.js
+++ b/tests/unit/ScrollableContainer.js
@@ -58,23 +58,20 @@ define([
 			w.style.width = "200px";
 			w.style.height = "200px";
 			container.appendChild(w);
-			w.startup();
+			w.attachedCallback();
 
 			var innerContent = document.createElement("div");
 			innerContent.id = "sc1content";
 			innerContent.style.width = "2000px";
 			innerContent.style.height = "2000px";
 			w.appendChild(innerContent);
-			w.startup();
 
 			w = new MyScrollableContainer({ id: "mysc1" });
 			container.appendChild(w);
-			w.startup();
 
 			w = new ScrollableContainer({ id: "sc2" });
 			w.scrollDirection = "none";
 			container.appendChild(w);
-			w.startup();
 		},
 		teardown: function () {
 			container.parentNode.removeChild(container);

--- a/tests/unit/Select.js
+++ b/tests/unit/Select.js
@@ -424,11 +424,11 @@ define([
 			
 			var w = new Select({ id: "select1" });
 			container.appendChild(w);
-			w.startup();
+			w.attachedCallback();
 			
 			w = new MySelect({ id: "myselect1" });
 			container.appendChild(w);
-			w.startup();
+			w.attachedCallback();
 		},
 		afterEach: function () {
 			container.parentNode.removeChild(container);

--- a/tests/unit/Slider.js
+++ b/tests/unit/Slider.js
@@ -188,14 +188,14 @@ define([
 	function createSingleSlider() {
 		var slider = new Slider();
 		document.body.appendChild(slider);
-		slider.startup();
+		slider.attachedCallback();
 		slider.deliver();
 		return slider;
 	}
 	function createDualSlider() {
 		var slider = new Slider({value: ","});
 		document.body.appendChild(slider);
-		slider.startup();
+		slider.attachedCallback();
 		slider.deliver();
 		return slider;
 	}

--- a/tests/unit/StarRating.js
+++ b/tests/unit/StarRating.js
@@ -11,7 +11,7 @@ define([
 		beforeEach: function () {
 			sr = new StarRating();
 			document.body.appendChild(sr);
-			sr.startup();
+			sr.attachedCallback();
 		},
 		"Setting different values for max": function () {
 			var dfd = this.async(1000);

--- a/tests/unit/Switch.js
+++ b/tests/unit/Switch.js
@@ -125,7 +125,7 @@ define([
 			document.body.appendChild(container);
 			var cb = new Switch({id: "sw1"});
 			container.appendChild(cb);
-			cb.startup();
+			cb.attachedCallback();
 			cb = new Switch({
 				id: "sw2",
 				value: "foo",
@@ -136,10 +136,10 @@ define([
 				uncheckedLabel: "OFF"
 			});
 			container.appendChild(cb);
-			cb.startup();
+			cb.attachedCallback();
 			cb = new Switch({id: "sw3"});
 			container.appendChild(cb);
-			cb.startup();
+			cb.attachedCallback();
 			var lbl = document.createElement("label");
 			lbl.setAttribute("for", "sw3");
 			lbl.setAttribute("id", "lbl4");

--- a/tests/unit/Toaster.js
+++ b/tests/unit/Toaster.js
@@ -43,7 +43,6 @@ define([
 		"Default values": function () {
 			var toasterDefault = new Toaster();
 			toasterDefault.placeAt("container");
-			toasterDefault.startup();
 			toasterDefault.deliver();
 
 			assert($(toasterDefault).hasClass("d-toaster-placement-default"),
@@ -73,7 +72,6 @@ define([
 			Object.keys(toasters).forEach(function (pos) {
 				toasters[pos] = new Toaster({placementClass: "d-toaster-placement-" + pos});
 				toasters[pos].placeAt("container");
-				toasters[pos].startup();
 				toasters[pos].deliver();
 				assert.isTrue($(toasters[pos]).hasClass("d-toaster-placement-" + pos),
 					"d-toaster-placement-" + pos + " CSS class has been correctly set");
@@ -82,7 +80,6 @@ define([
 		"Checking raw message creation and posting": function () {
 			var toast = new Toaster();
 			toast.placeAt("container");
-			toast.startup();
 
 			// creating the messages
 			var makeMessage = function (i) {
@@ -103,7 +100,6 @@ define([
 		"Checking message widget creation and posting": function () {
 			var toast = new Toaster();
 			toast.placeAt("container");
-			toast.startup();
 
 			// creating the messages
 			var makeMessage = function (i) {
@@ -128,7 +124,6 @@ define([
 		"Testing behaviour of _allExpAreRemovable and _getRemovableMsg": function () {
 			var toast = new Toaster();
 			toast.placeAt("container");
-			toast.startup();
 
 			var resetToast = function () {
 				toast.messages = [];
@@ -193,8 +188,6 @@ define([
 		"Checking _nonRemovableAreOnlyPersistent behaviour": function () {
 			var i, N = 20, m, toast = new Toaster();
 			toast.placeAt("container");
-			toast.startup();
-
 
 			// some messages are removable and some are not
 			// some messages are persistent and some are not

--- a/tests/unit/ToasterMessage-insert-show-hide-remove.js
+++ b/tests/unit/ToasterMessage-insert-show-hide-remove.js
@@ -19,7 +19,6 @@ define([
 			// setting up the toaster
 			toaster = new Toaster();
 			toaster.placeAt(container);
-			toaster.startup();
 
 			// setting the wrapper
 			wrapper = toaster._wrapper;

--- a/tests/unit/ToasterMessage.js
+++ b/tests/unit/ToasterMessage.js
@@ -17,7 +17,6 @@ define([
 
 			toaster = new Toaster();
 			toaster.placeAt("container");
-			toaster.startup();
 		},
 		"Default values": function () {
 			var messageDefault = new ToasterMessage();

--- a/tests/unit/Toggle.js
+++ b/tests/unit/Toggle.js
@@ -73,10 +73,10 @@ define([
 			document.body.appendChild(container);
 			widget = new MyWidget({id: "cb1"});
 			container.appendChild(widget);
-			widget.startup();
+			widget.attachedCallback();
 			widget = new MyWidget({id: "cb2", checked: true, value: "foo"});
 			container.appendChild(widget);
-			widget.startup();
+			widget.attachedCallback();
 		}
 	};
 	dcl.mix(suite, commonSuite);

--- a/tests/unit/ToggleButton.js
+++ b/tests/unit/ToggleButton.js
@@ -139,17 +139,17 @@ define([
 			document.body.appendChild(container);
 			var tb = new ToggleButton({id: "tb1", label: "tb1"});
 			container.appendChild(tb);
-			tb.startup();
+			tb.attachedCallback();
 			tb = new ToggleButton({id: "tb2", value: "foo", label: "tb2"});
 			container.appendChild(tb);
-			tb.startup();
+			tb.attachedCallback();
 			tb = new ToggleButton({id: "tb3", checked: "checked", label: "tb3", iconClass: "ic1"});
 			container.appendChild(tb);
-			tb.startup();
+			tb.attachedCallback();
 			tb = new ToggleButton({id: "tb4", checked: "checked", label: "off", checkedLabel: "on",
 				iconClass: "ic1", checkedIconClass: "ic2"});
 			container.appendChild(tb);
-			tb.startup();
+			tb.attachedCallback();
 		}
 	};
 	dcl.mix(suite, commonSuite);

--- a/tests/unit/bidi/Button.js
+++ b/tests/unit/bidi/Button.js
@@ -87,7 +87,7 @@ define([
 				moduleRequire(["delite/register", "deliteful/Button"], dfd.callback(function (register, Button) {
 					var b1 = new Button({id: "b1", label: "\u05d0\u05d1\u05d2 ABC", title: "ABC \u05d0\u05d1\u05d2"});
 					container.appendChild(b1);
-					b1.startup();
+					b1.attachedCallback();
 					b1.textDir = "ltr";
 					b1.deliver();
 					assert.strictEqual("\u202a\u05d0\u05d1\u05d2 ABC\u202c", b1.labelNode.textContent,
@@ -113,7 +113,7 @@ define([
 				moduleRequire(["delite/register", "deliteful/Button"], dfd.callback(function (register, Button) {
 					var b2 = new Button({id: "b2"});
 					container.appendChild(b2);
-					b2.startup();
+					b2.attachedCallback();
 					b2.textDir = "rtl";
 					b2.label = "ABC \u05d0\u05d1\u05d2";
 					b2.deliver();
@@ -131,7 +131,7 @@ define([
 				moduleRequire(["delite/register", "deliteful/Button"], dfd.callback(function (register, Button) {
 					var b3 = new Button({id: "b3"});
 					container.appendChild(b3);
-					b3.startup();
+					b3.attachedCallback();
 					b3.textDir = "auto";
 					b3.title = "\u05d0\u05d1\u05d2 ABC";
 					b3.deliver();

--- a/tests/unit/bidi/ToggleButton.js
+++ b/tests/unit/bidi/ToggleButton.js
@@ -103,7 +103,7 @@ define([
 					var b1 = new ToggleButton({id: "b1", label: "\u05d0\u05d1\u05d2 ABC",
 						title: "ABC \u05d0\u05d1\u05d2", checkedLabel: "ABC \u05d2\u05d1\u05d0"});
 					container.appendChild(b1);
-					b1.startup();
+					b1.attachedCallback();
 					b1.textDir = "ltr";
 					b1.deliver();
 					assert.strictEqual("\u202a\u05d0\u05d1\u05d2 ABC\u202c", b1.labelNode.textContent,
@@ -143,7 +143,7 @@ define([
 					dfd.callback(function (register, ToggleButton) {
 					var b2 = new ToggleButton({id: "b2"});
 					container.appendChild(b2);
-					b2.startup();
+					b2.attachedCallback();
 					b2.textDir = "rtl";
 					b2.label = "ABC \u05d0\u05d1\u05d2";
 					b2.deliver();
@@ -162,7 +162,7 @@ define([
 					dfd.callback(function (register, ToggleButton) {
 					var b2 = new ToggleButton({id: "b2", checked: true});
 					container.appendChild(b2);
-					b2.startup();
+					b2.attachedCallback();
 					b2.textDir = "rtl";
 					b2.checkedLabel = "ABC \u05d0\u05d1\u05d2";
 					b2.deliver();
@@ -181,7 +181,7 @@ define([
 					dfd.callback(function (register, ToggleButton) {
 					var b3 = new ToggleButton({id: "b3"});
 					container.appendChild(b3);
-					b3.startup();
+					b3.attachedCallback();
 					b3.textDir = "auto";
 					b3.title = "\u05d0\u05d1\u05d2 ABC";
 					b3.deliver();

--- a/tests/unit/list/AriaListbox.js
+++ b/tests/unit/list/AriaListbox.js
@@ -19,7 +19,7 @@ define([
 			list = new List({store: new Store()});
 			list.setAttribute("role", "listbox");
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.store.filter();
 			list.store.add({label: "item 1"});
 			list.store.add({label: "item 2"});

--- a/tests/unit/list/Categories.js
+++ b/tests/unit/list/Categories.js
@@ -30,7 +30,7 @@ define([
 			}
 			list = new List({store: new Store()});
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.store.filter();
 			list.categoryAttr = "category";
 			list.store.add({category: "A", label: "item 1"});
@@ -316,7 +316,7 @@ define([
 			list = null;
 			list = new List({store: new Store()});
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.store.filter();
 			list.categoryAttr = "category";
 			list.store.add({category: "A", label: "item 4"});

--- a/tests/unit/list/PageableList.js
+++ b/tests/unit/list/PageableList.js
@@ -137,7 +137,7 @@ define([
 			list.pageLength = 23;
 			list.maxPages = 2;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			// initial load (page 1 loaded)
 			assertList(list, 0, 22, [], false, true, "initial load");
@@ -219,7 +219,7 @@ define([
 			list.pageLength = 23;
 			list.maxPages = 2;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			// initial load (page 1 loaded)
 			list.deliver();
 			assertList(list, 0, 22, [], false, true, "assert 1");
@@ -241,7 +241,7 @@ define([
 			list.pageLength = 23;
 			list.maxPages = 2;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			clickNextPageLoader(list).then(dfd.rejectOnError(function () {
 				clickNextPageLoader(list).then(dfd.rejectOnError(function () {
@@ -270,7 +270,7 @@ define([
 			list.maxPages = 2;
 			list.style.height = "200px";
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			// Click next page loader three times
 			clickNextPageLoader(list).then(dfd.rejectOnError(function () {
@@ -304,7 +304,7 @@ define([
 			list.maxPages = 2;
 			list.style.height = "200px";
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			// Click next page loader two times
 			clickNextPageLoader(list).then(dfd.rejectOnError(function () {
@@ -329,7 +329,7 @@ define([
 			list.pageLength = 23;
 			list.maxPages = 2;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			list.store.add({id: "A", label: "item A"}, {beforeId: 1});
 			list.store.add({id: "B", label: "item B"}, {beforeId: 22});
@@ -429,7 +429,7 @@ define([
 			list.pageLength = 23;
 			list.maxPages = 2;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			list.store.add({id: "A", label: "item A"}, {beforeId: 0});
 			list.deliver();
@@ -470,7 +470,7 @@ define([
 			list.pageLength = 23;
 			list.maxPages = 0;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			assert.strictEqual(list.children.length, 24, "0: number of list children");
 			assert.strictEqual(removeTabsAndReturns(list.children[23].textContent),
@@ -513,7 +513,7 @@ define([
 			list.pageLength = 23;
 			list.maxPages = 1;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.store.add({id: "A", label: "item A"}, {beforeId: 23});
 			list.deliver();
 			assertList(list, 0, 22, [], false, true, "A");
@@ -669,7 +669,7 @@ define([
 			list.pageLength = 20;
 			list.maxPages = 0;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			// initial load
 			assertList(list, 0, 19, [], false, true);
@@ -710,7 +710,7 @@ define([
 			list.maxPages = 0;
 			list.categoryAttr = "category";
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			// initial load
 			assertCategorizedList(list, 25, 0, false, true);
@@ -746,7 +746,7 @@ define([
 			list.pageLength = 20;
 			list.maxPages = 2;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			// initial load
 			assertList(list, 0, 19, [], false, true);
@@ -804,7 +804,7 @@ define([
 			list.pageLength = 25;
 			list.maxPages = 2;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			// initial load
 			assertCategorizedList(list, 25, 0, false, true);
@@ -849,7 +849,7 @@ define([
 			list.pageLength = 100;
 			list.maxPages = 0;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			// initial load
 			assertList(list, 0, 99, [], false, true);
@@ -870,7 +870,7 @@ define([
 			list.pageLength = 100;
 			list.maxPages = 0;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			// initial load
 			list.deliver();
 			assertCategorizedList(list, 100, 0, false, true);
@@ -890,7 +890,7 @@ define([
 			list.pageLength = 100;
 			list.maxPages = 0;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			// initial load
 			list.deliver();
 			assertList(list, 0, 99, [], false, true);
@@ -911,7 +911,7 @@ define([
 			list.pageLength = 100;
 			list.maxPages = 0;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			// initial load
 			assertCategorizedList(list, 100, 0, false, true);
@@ -930,7 +930,7 @@ define([
 			list.pageLength = 101;
 			list.maxPages = 0;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			// initial load
 			list.deliver();
 			assertList(list, 0, 99, [], false, false);
@@ -944,7 +944,7 @@ define([
 			list.pageLength = 101;
 			list.maxPages = 0;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			// initial load
 			assertCategorizedList(list, 100, 0, false, false);
@@ -957,7 +957,7 @@ define([
 			list.pageLength = 101;
 			list.maxPages = 0;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			// initial load
 			assertList(list, 0, 99, [], false, false);
@@ -971,7 +971,7 @@ define([
 			list.pageLength = 101;
 			list.maxPages = 0;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			// initial load
 			assertCategorizedList(list, 100, 0, false, false);
@@ -1021,7 +1021,7 @@ define([
 			list.pageLength = 25;
 			list.maxPages = 0;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			// initial load
 			list.deliver();
 			assertCategorizedList(list, 25, 0, false, true);
@@ -1048,7 +1048,7 @@ define([
 			list.pageLength = 10;
 			list.maxPages = 2;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			clickNextPageLoader(list).then(dfd.rejectOnError(function () {
 				list.deliver();
@@ -1078,7 +1078,7 @@ define([
 			list.pageLength = 10;
 			list.maxPages = 2;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			clickNextPageLoader(list).then(dfd.rejectOnError(function () {
 				clickNextPageLoader(list).then(dfd.rejectOnError(function () {
@@ -1106,7 +1106,7 @@ define([
 			list.pageLength = 10;
 			list.maxPages = 1;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			clickNextPageLoader(list).then(dfd.callback(function () {
 				list.deliver();
@@ -1127,7 +1127,7 @@ define([
 			list.pageLength = 10;
 			list.maxPages = 1;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			clickNextPageLoader(list).then(dfd.callback(function () {
 				list.deliver();
@@ -1151,7 +1151,7 @@ define([
 			list.pageLength = 20;
 			list.maxPages = 0;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			// initial load
 			assertList(list, 0, 19, [], false, true);
@@ -1183,7 +1183,7 @@ define([
 				list.store.add({label: "item " + i, category: "Category " + Math.floor(i / 10)});
 			}
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			// initial load
 			assertCategorizedList(list, 25, 0, false, true);
@@ -1247,7 +1247,7 @@ define([
 			list.pageLength = 10;
 			list.maxPages = 1;
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.deliver();
 			clickNextPageLoader(list).then(dfd.callback(function () {
 				list.deliver();

--- a/tests/unit/list/Selection.js
+++ b/tests/unit/list/Selection.js
@@ -263,7 +263,7 @@ define([
 			}
 			list = new List({store: new Store()});
 			document.body.appendChild(list);
-			list.startup();
+			list.attachedCallback();
 			list.store.filter();
 			list.store.add({label: "item 1"});
 			list.store.add({label: "item 2"});

--- a/tests/unit/list/resources/ListBaseTests.js
+++ b/tests/unit/list/resources/ListBaseTests.js
@@ -10,7 +10,7 @@ define([
 
 	return {
 		/**
-		 *Build a test suite for a List class
+		 * Build a test suite for a List class
 		 * @param name {string} the name of the test suite
 		 * @param ListConstructor {function} the constructor for the tested List class
 		 */
@@ -23,7 +23,7 @@ define([
 					}
 					this.list = new ListConstructor({store: new Store()});
 					document.body.appendChild(this.list);
-					this.list.startup();
+					this.list.attachedCallback();
 					this.list.store.add({label: "item 1"});
 					this.list.store.add({label: "item 2"});
 					this.list.store.add({label: "item 3"});
@@ -187,7 +187,8 @@ define([
 					var list = this.parent.list;
 					list.destroy();
 					list = new ListConstructor({store: new Store()});
-					list.startup();
+					document.body.appendChild(list);
+					list.attachedCallback();
 					list.store.add({label: "item 1", category: "category 1"});
 					assert.strictEqual(list.children[0].item.category, "category 1");
 				},
@@ -207,7 +208,8 @@ define([
 					list.labelAttr = "name";
 					list.store.add({name: "item 1"});
 					list.store.add({name: "item 2"});
-					list.startup();
+					document.body.appendChild(list);
+					list.attachedCallback();
 					return def;
 				},
 				"query-error event": function () {
@@ -232,7 +234,8 @@ define([
 						list.on("query-error", function (evt) {
 							queryErrorEvt = evt;
 						});
-						list.startup();
+						document.body.appendChild(list);
+						list.attachedCallback();
 						setTimeout(def.callback(function () {
 							assert.isNotNull(queryErrorEvt);
 							assert.strictEqual("Query Error X", queryErrorEvt.error, "error message");


### PR DESCRIPTION
Changes to doc, samples, and tests to remove unneeded startup() calls and convert other startup() calls to attachedCallback()

Reasoning: eventually we'll probably remove the startup() method, and instead:

1. either tell the users to call attachedCallback() instead of startup()
2. or perhaps we will set up listeners to call attachedCallback() automatically.

But for now we can avoid that whole issue by using Widget#placeAt() to position the node in the DOM tree.  placeAt() already calls attachedCallback(), thus there's no need for a manual call to startup().