### PR TITLE
ViewIndicator CSS improvements

### DIFF
--- a/ViewIndicator/themes/ViewIndicator_template.less
+++ b/ViewIndicator/themes/ViewIndicator_template.less
@@ -1,12 +1,13 @@
 @import "../../../../delite/themes/common/mixins";
 
 .d-view-indicator {
+	display: block;
 	text-align: center;
 	.user-select(none);
 	cursor: default;
 }
 
-.d-view-indicator, .d-view-indicator * {
+.d-view-indicator * {
 	display: inline-block;
 }
 
@@ -14,7 +15,6 @@
 	width: @dot-size;
 	height: @dot-size;
 	.border-radius(@dot-size / 2);
-	line-height: @dot-size;
 	margin: @dot-margin;
 	background-color: @dot-color;
 }
@@ -23,12 +23,13 @@
 	background-color: @dot-selected-color;
 }
 
+// High-contrast mode is supported through actual characters
+// There characters are not visible in normal mode
 .d-view-indicator .-d-view-indicator-dot::before {
-	font-size: @dot-glyph-font-size;
 	color: transparent;
-	content: "\25CB";
+	content: "\25CB"; // White circle character
 }
 
 .d-view-indicator .-d-view-indicator-dot-selected::before {
-	content: "\25CF";
+	content: "\25CF"; // Black circle character
 }

--- a/ViewIndicator/themes/bootstrap/ViewIndicator.css
+++ b/ViewIndicator/themes/bootstrap/ViewIndicator.css
@@ -1,4 +1,5 @@
 .d-view-indicator {
+  display: block;
   text-align: center;
   user-select: none;
   -webkit-user-select: none;
@@ -6,24 +7,21 @@
   -moz-user-select: none;
   cursor: default;
 }
-.d-view-indicator,
 .d-view-indicator * {
   display: inline-block;
 }
 .d-view-indicator .-d-view-indicator-dot {
-  width: 6px;
-  height: 6px;
-  -moz-border-radius: 3px;
-  border-radius: 3px;
-  line-height: 6px;
-  margin: 6px;
+  width: 0.75em;
+  height: 0.75em;
+  -moz-border-radius: 0.375em;
+  border-radius: 0.375em;
+  margin: 0.5em;
   background-color: #999999;
 }
 .d-view-indicator .-d-view-indicator-dot-selected {
   background-color: #ffffff;
 }
 .d-view-indicator .-d-view-indicator-dot::before {
-  font-size: 14px;
   color: transparent;
   content: "\25CB";
 }

--- a/ViewIndicator/themes/bootstrap/ViewIndicator.less
+++ b/ViewIndicator/themes/bootstrap/ViewIndicator.less
@@ -1,8 +1,7 @@
 @import "../../../../delite/themes/bootstrap/includes";
 
-@dot-size: 6px;
-@dot-margin: 6px;
-@dot-glyph-font-size: 14px;
+@dot-size: 0.75em;
+@dot-margin: 0.5em;
 @dot-color: @gray-light;
 @dot-selected-color: white;
 

--- a/ViewIndicator/themes/holodark/ViewIndicator.css
+++ b/ViewIndicator/themes/holodark/ViewIndicator.css
@@ -1,4 +1,5 @@
 .d-view-indicator {
+  display: block;
   text-align: center;
   user-select: none;
   -webkit-user-select: none;
@@ -6,24 +7,21 @@
   -moz-user-select: none;
   cursor: default;
 }
-.d-view-indicator,
 .d-view-indicator * {
   display: inline-block;
 }
 .d-view-indicator .-d-view-indicator-dot {
-  width: 6px;
-  height: 6px;
-  -moz-border-radius: 3px;
-  border-radius: 3px;
-  line-height: 6px;
-  margin: 6px;
+  width: 0.75em;
+  height: 0.75em;
+  -moz-border-radius: 0.375em;
+  border-radius: 0.375em;
+  margin: 0.5em;
   background-color: #999999;
 }
 .d-view-indicator .-d-view-indicator-dot-selected {
   background-color: #ffffff;
 }
 .d-view-indicator .-d-view-indicator-dot::before {
-  font-size: 14px;
   color: transparent;
   content: "\25CB";
 }

--- a/ViewIndicator/themes/holodark/ViewIndicator.less
+++ b/ViewIndicator/themes/holodark/ViewIndicator.less
@@ -1,8 +1,7 @@
 @import "../../../../delite/themes/bootstrap/includes";
 
-@dot-size: 6px;
-@dot-margin: 6px;
-@dot-glyph-font-size: 14px;
+@dot-size: 0.75em;
+@dot-margin: 0.5em;
 @dot-color: @gray-light;
 @dot-selected-color: white;
 

--- a/ViewIndicator/themes/ios/ViewIndicator.css
+++ b/ViewIndicator/themes/ios/ViewIndicator.css
@@ -1,4 +1,5 @@
 .d-view-indicator {
+  display: block;
   text-align: center;
   user-select: none;
   -webkit-user-select: none;
@@ -6,24 +7,21 @@
   -moz-user-select: none;
   cursor: default;
 }
-.d-view-indicator,
 .d-view-indicator * {
   display: inline-block;
 }
 .d-view-indicator .-d-view-indicator-dot {
-  width: 6px;
-  height: 6px;
-  -moz-border-radius: 3px;
-  border-radius: 3px;
-  line-height: 6px;
-  margin: 6px;
+  width: 0.75em;
+  height: 0.75em;
+  -moz-border-radius: 0.375em;
+  border-radius: 0.375em;
+  margin: 0.5em;
   background-color: #999999;
 }
 .d-view-indicator .-d-view-indicator-dot-selected {
   background-color: #ffffff;
 }
 .d-view-indicator .-d-view-indicator-dot::before {
-  font-size: 14px;
   color: transparent;
   content: "\25CB";
 }

--- a/ViewIndicator/themes/ios/ViewIndicator.less
+++ b/ViewIndicator/themes/ios/ViewIndicator.less
@@ -1,8 +1,7 @@
 @import "../../../../delite/themes/bootstrap/includes";
 
-@dot-size: 6px;
-@dot-margin: 6px;
-@dot-glyph-font-size: 14px;
+@dot-size: 0.75em;
+@dot-margin: 0.5em;
 @dot-color: @gray-light;
 @dot-selected-color: white;
 


### PR DESCRIPTION
 - Default display from inline-block to block (looks more natural)
 - Dot size: from 6px to 0.75em (a bit larger and scalable)
 - Margin from 6px to 0.5em
 - Add some comments for high-contrast support
 - Remove hard-coded line-height