### PR TITLE
ProgressBar CSS improvements

### DIFF
--- a/ProgressBar/themes/ProgressBar_template.less
+++ b/ProgressBar/themes/ProgressBar_template.less
@@ -1,6 +1,6 @@
 .d-progress-bar {
   display: inline-block;
-  position: relative;
+  position: relative; // Needed for absolutely positioned children
   padding: 0;
   width: 100%;
   .d-progress-bar-styles;
@@ -28,7 +28,7 @@
   width: 100%;
   margin: 0;
   padding: 0;
-  overflow: hidden;
+  overflow: hidden; // Needed for the alignment of the two parts of the text
   .d-progress-bar-msg-styles;
 }
 
@@ -42,7 +42,7 @@
 
 .d-progress-bar-msg-ext {
   .d-progress-bar-msg-ext-styles;
-  overflow: hidden;
+  overflow: hidden; // Needed for the alignment of the two parts of the text
 }
 
 .d-progress-bar-indeterminate .d-progress-bar-background {

--- a/ProgressBar/themes/bootstrap/ProgressBar.css
+++ b/ProgressBar/themes/bootstrap/ProgressBar.css
@@ -39,7 +39,6 @@
   margin: 0;
   padding: 0;
   position: absolute;
-  overflow: hidden;
   top: 0;
   height: 100%;
   background-color: #f5f5f5;
@@ -63,6 +62,7 @@
   padding: 0;
   overflow: hidden;
   position: absolute;
+  font-size: inherit;
   height: 100%;
   width: 100%;
   left: 0;
@@ -72,6 +72,7 @@
 }
 .d-progress-bar-msg-invert {
   position: absolute;
+  font-size: inherit;
   overflow: hidden;
   height: 100%;
   white-space: nowrap;

--- a/ProgressBar/themes/bootstrap/ProgressBar.less
+++ b/ProgressBar/themes/bootstrap/ProgressBar.less
@@ -25,18 +25,17 @@
 
 .d-progress-bar-styles() {
 	font-size: @font-size-small;
-	height: 1.8em;
+	height: @height;
 	vertical-align: middle;
-	overflow: hidden;
-	text-align: center; //use 'initial' to override and restore default value (left if ltr, right if rtl)
+	overflow: hidden; // Corners clipping
+	text-align: center; // Use 'initial' to override and restore default value (left if ltr, right if rtl)
 	.box-sizing(border-box);
 	.border-radius(4px);
-	border: 1px solid transparent; //a11y: high contrast
+	border: 1px solid transparent; // a11y: high contrast
 }
 
 .d-progress-bar-background-styles() {
 	position: absolute;
-	overflow: hidden;
 	top: 0;
 	height: 100%;
 	background-color: @progress-bg;
@@ -45,7 +44,7 @@
 
 .d-progress-bar-indicator-styles() {
 	position: relative;
-	overflow: hidden;
+	overflow: hidden; // Needed for the alignment of the two parts of the text
 	height: 100%;
 	.transition(width @transition-params);
 	background-color: @progress-bar-bg;
@@ -61,6 +60,7 @@
 
 .d-progress-bar-msg-styles() {
 	position: absolute;
+	font-size: inherit;
 	height: 100%;
 	width: 100%;
 	left: 0;
@@ -75,7 +75,8 @@
 
 .d-progress-bar-msg-invert-styles() {
 	position: absolute;
-	overflow: hidden;
+	font-size: inherit;
+	overflow: hidden; // Needed by text-overflow
 	height: 100%;
 	white-space: nowrap;
 	line-height: @line-height;

--- a/ProgressBar/themes/bootstrap/variables.less
+++ b/ProgressBar/themes/bootstrap/variables.less
@@ -1,2 +1,3 @@
-@transition-params: 0.3s linear 0s;
-@line-height: 1.6em;
+@height: 1.8em; // Controls the height of the widget (180% of the font-size)
+@line-height: 1.6em; // Controls the vertical position of the text
+@transition-params: 0.3s linear 0s; // Controls the animation


### PR DESCRIPTION
 - Add a LESS variable @height for consistency with @line-height. These two variables control the default height of the widget and the default vertical position of the text
 - Ensure inner font size inherit the widget font-size
 - Add some comments, remove a "overflow:hidden" not needed