### PR TITLE
Fixed Switch high contrast mode, fixes #477

### DIFF
--- a/Switch/themes/Switch_template.less
+++ b/Switch/themes/Switch_template.less
@@ -17,7 +17,12 @@
 }
 
 // internal classes
-
+.-d-switch-block {
+	display: inline-block;
+	position: absolute;
+	top:0;
+	border-width: 0px;
+}
 .-d-switch-inner {
 	position:absolute;
 	width: @d-switch-knob-w;
@@ -50,6 +55,7 @@
 	left: 50%;
 	margin-left: -@d-switch-knob-w/2;
 	z-index:5;
+
 	.d-switch-knob-styles();
 }
 
@@ -61,12 +67,7 @@
 	z-index: 10;
 }
 
-.-d-switch-block {
-	display: inline-block;
-	position: absolute;
-	top:0;
-	border-width: 0px;
-}
+
 
 .-d-switch-inner-wrapper {
 	position:relative;

--- a/Switch/themes/bootstrap/Switch.css
+++ b/Switch/themes/bootstrap/Switch.css
@@ -17,6 +17,12 @@
 .d-switch.d-disabled {
   opacity: .6;
 }
+.-d-switch-block {
+  display: inline-block;
+  position: absolute;
+  top: 0;
+  border-width: 0px;
+}
 .-d-switch-inner {
   position: absolute;
   width: 30px;
@@ -56,6 +62,8 @@
   z-index: 5;
   box-shadow: 0 1px 6px #a2a2a2;
   background: #eeeeee;
+  border: 1px solid transparent;
+  top: -1px;
 }
 .-d-switch-knobglass {
   display: inline-block;
@@ -63,12 +71,6 @@
   width: 30px;
   height: 100%;
   z-index: 10;
-}
-.-d-switch-block {
-  display: inline-block;
-  position: absolute;
-  top: 0;
-  border-width: 0px;
 }
 .-d-switch-inner-wrapper {
   position: relative;

--- a/Switch/themes/bootstrap/Switch.less
+++ b/Switch/themes/bootstrap/Switch.less
@@ -15,6 +15,8 @@
 .d-switch-knob-styles() {
 	box-shadow: 0 1px 6px darken(@gray-lighter, 30%);
 	background: @gray-lighter;
+	border: 1px solid transparent; // NOTE: becomes visible in high contrast mode. 
+	top: -1px; // NOTE: compensates for the above border
 }
 .d-switch-styles() {
 	border: 1px solid darken(@gray-lighter, 15%);

--- a/Switch/themes/holodark/Switch.css
+++ b/Switch/themes/holodark/Switch.css
@@ -16,6 +16,12 @@
 .d-switch.d-disabled {
   opacity: .6;
 }
+.-d-switch-block {
+  display: inline-block;
+  position: absolute;
+  top: 0;
+  border-width: 0px;
+}
 .-d-switch-inner {
   position: absolute;
   width: 30px;
@@ -63,12 +69,6 @@
   width: 30px;
   height: 100%;
   z-index: 10;
-}
-.-d-switch-block {
-  display: inline-block;
-  position: absolute;
-  top: 0;
-  border-width: 0px;
 }
 .-d-switch-inner-wrapper {
   position: relative;

--- a/Switch/themes/ios/Switch.css
+++ b/Switch/themes/ios/Switch.css
@@ -17,6 +17,12 @@
 .d-switch.d-disabled {
   opacity: .6;
 }
+.-d-switch-block {
+  display: inline-block;
+  position: absolute;
+  top: 0;
+  border-width: 0px;
+}
 .-d-switch-inner {
   position: absolute;
   width: 30px;
@@ -68,12 +74,6 @@
   width: 30px;
   height: 100%;
   z-index: 10;
-}
-.-d-switch-block {
-  display: inline-block;
-  position: absolute;
-  top: 0;
-  border-width: 0px;
 }
 .-d-switch-inner-wrapper {
   position: relative;

--- a/samples/Switch.html
+++ b/samples/Switch.html
@@ -6,7 +6,7 @@
 	      content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no"/>
 	<meta name="apple-mobile-web-app-capable" content="yes"/>
 
-	<title>Checkbox samples</title>
+	<title>Switch samples</title>
 
 	<script type="text/javascript" src="../../requirejs/require.js"></script>
 
@@ -20,23 +20,17 @@
 	<script type="text/javascript">
 		require([
 			"delite/register",
-			"deliteful/Checkbox",
+			"deliteful/Switch",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function (register, Checkbox) {
+		], function (register, Switch) {
 			register.parse();
 			document.body.style.display = "";
 		});
 	</script>
 </head>
-<style>
-</style>
 <body style="display: none">
-	<label>
-		<d-checkbox name="options" checked="true"></d-checkbox>
-		Option 1
-	</label>
-	<d-checkbox name="options" id="option2"></d-checkbox>
-	<label for="option2"> Option 2 </label>
+<d-switch checkedLabel="ON" uncheckedLabel="OFF" name="bluetooth" ></d-switch>
+<d-switch checkedLabel="ON" uncheckedLabel="OFF" name="bluetooth" disabled></d-switch>
 </body>
 </html>


### PR DESCRIPTION
- Added a transparent border that will show in high contrast mode while
still invisible in normal mode.
- fixing checkbox sample title
- added a standelone sample for switch

Here's how it looks now in high contrast mode. (Tested under firefox and ie)
![image](https://cloud.githubusercontent.com/assets/2982512/6018336/33e64e56-ab96-11e4-8c01-552719712fed.png)
