### PR TITLE
Made Button a container, solves #290

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -3,11 +3,11 @@ define([
 	"dcl/dcl",
 	"requirejs-dplugins/has",
 	"delite/register",
-	"delite/Widget",
+	"delite/Container",
 	"requirejs-dplugins/has!bidi?./Button/bidi/Button",
 	"delite/handlebars!./Button/Button.html",
 	"delite/theme!./Button/themes/{{theme}}/Button.css"
-], function (dcl, has, register, Widget, BidiButton, template) {
+], function (dcl, has, register, Container, BidiButton, template) {
 
 	/**
 	 * A Non-templated form-aware button widget.
@@ -23,9 +23,9 @@ define([
 	 * </style>
 	 * <button is="d-button" iconClass="iconForButton">Click Me</button>
 	 * @class module:deliteful/Button
-	 * @augments module:delite/Widget
+	 * @augments module:delite/Container
 	 */
-	var Button = dcl(Widget, /** @lends module:deliteful/Button# */ {
+	var Button = dcl(Container, /** @lends module:deliteful/Button# */ {
 
 		/**
 		 * The text to display in the button.
@@ -49,14 +49,6 @@ define([
 		baseClass: "d-button",
 
 		template: template,
-
-		preRender: function () {
-			// Get label from innerHTML, and then clear it since we are to put the label in a <span>
-			if (!this.label) {
-				this.label = this.textContent.trim();
-				this.innerHTML = "";
-			}
-		},
 
 		computeProperties: function (props) {
 			if ("title" in props || "label" in props) {

--- a/Button/Button.html
+++ b/Button/Button.html
@@ -1,4 +1,5 @@
 <template attach-point="focusNode">
-	<span attach-point="iconNode" class="d-icon {{this.iconClass ? this.iconClass : 'd-hidden'}}"></span
+	<span attach-point="containerNode"></span
+	><span attach-point="iconNode" class="d-icon {{this.iconClass ? this.iconClass : 'd-hidden'}}"></span		
 	><span attach-point="labelNode" d-hidden="{{!this.label}}">{{label}}</span>
 </template>

--- a/ToggleButton/ToggleButton.html
+++ b/ToggleButton/ToggleButton.html
@@ -1,4 +1,5 @@
 <template aria-pressed="{{checked}}" attach-point="focusNode" on-click="{{toggle}}">
-	<span attach-point="iconNode" class="d-icon {{this.checked &amp;&amp; this.checkedIconClass ? this.checkedIconClass : (this.iconClass ? this.iconClass : 'd-hidden')}}"
+	<span attach-point="containerNode"></span
+    ><span attach-point="iconNode" class="d-icon {{this.checked &amp;&amp; this.checkedIconClass ? this.checkedIconClass : (this.iconClass ? this.iconClass : 'd-hidden')}}"
 	></span><span attach-point="labelNode" d-hidden="{{!this.checkedLabel &amp;&amp; !this.label}}">{{this.checked &amp;&amp; this.checkedLabel ? this.checkedLabel : this.label}}</span>
 </template>

--- a/docs/Button.md
+++ b/docs/Button.md
@@ -21,7 +21,7 @@ The `deliteful/Button` widget is a push button that can display a label and / or
 <a name="instantiation"></a>
 ## Element Instantiation
 
-See [`delite/Widget`](/delite/docs/master/Widget.md) for full details on how instantiation lifecycle is working.
+See [`delite/Widget`](/delite/docs/master/Widget.md) as well as [`delite/Container`](/delite/docs/master/Container.md) for full details on how instantiation lifecycle is working.
 
 ### Declarative Instantiation
 
@@ -52,6 +52,7 @@ The following properties can be set on the widget to configure it:
 * `iconClass`: DOM class to apply to a DOM node before the label in order to render an icon;
 * `showLabel`: set it to true so that the button only displays an icon (especially useful for buttons in toolbars).
 
+The icon and label get appended to whatever was declared inside `<d-button>`.
 The `disabled` attribute is also supported, in order to disable the button. A disabled button appears as disabled and does not emit any event when clicked.
 
 <a name="styling"></a>
@@ -117,7 +118,7 @@ The widget has the same accessibility than a standard HTML 5 `<button>` element.
 
 ### Globalization
 
-This widget does not provide any internationalizable bundle. The only string displayed by the button is the one defined by its `label` property.
+This widget does not provide any internationalizable bundle.
 
 This widget supports both left to right and right to left orientation.
 

--- a/samples/Button.html
+++ b/samples/Button.html
@@ -64,11 +64,11 @@
 </head>
 <body style="display: none; background-color:white;">
 <div class="group">
-	<button is="d-button" label="Default button" onclick="alert(this.label + ' clicked.');"></button>
+	<button is="d-button" onclick="alert('clicked.');">Defaut button</button>
+	<button is="d-button" label="Default button with label" onclick="alert(this.label + ' clicked.');"></button>
 	<button is="d-button" class="d-button-blue" label="Blue button" onclick="alert(this.label + ' clicked.');"></button>
 	<button is="d-button" class="d-button-red" label="Red button" onclick="alert(this.label + ' clicked.');"></button>
 	<button is="d-button" iconClass = 'd-icon-phone' label="Custom with icon" class="d-button-green" onclick="alert(this.label + ' clicked.');"></button>
-	<button is="d-button" iconClass = 'd-icon-phone d-big-icon' label="Custom with icon" class="d-button-green" onclick="alert(this.label + ' clicked.');"></button>
 </div>
 </body>
 </html>

--- a/samples/ToggleButton.html
+++ b/samples/ToggleButton.html
@@ -20,22 +20,32 @@
 		require([
 			"delite/register",
 			"deliteful/ToggleButton",
+			"deliteful/ProgressIndicator",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
 		], function (register) {
 			register.parse();
 			document.body.style.display = "";
+			window.refresh = function() {
+				progress.style.display = progress.style.display ? "": "none";
+			}
 		});
 	</script>
 	<style>
 		.icon-star-empty:before { content: "☆"; }
 		.icon-star-full:before { content: "★"; }
+		#progress {
+			width: 1em; height: 1em;
+		}
 	</style>
 </head>
 <body style="display: none">
 	<button is="d-toggle-button">Wifi</button>
 	<button is="d-toggle-button" checked>Wifi</button>
-	<button is="d-toggle-button" checkedLabel="Enabled">Enable</button>
-	<button is="d-toggle-button" checkedLabel="Bookmarked" iconClass="icon-star-empty" checkedIconClass="icon-star-full">Bookmark</button>
+	<button is="d-toggle-button" checkedLabel="Enabled" label="Enable"></button>
+	<button is="d-toggle-button" checkedLabel="Bookmarked" label="Bookmark" iconClass="icon-star-empty" checkedIconClass="icon-star-full"></button>
+	<button is="d-toggle-button" checkedLabel="refreshing..." label="refresh" onclick="refresh()">
+		<d-progress-indicator id="progress" active="true" style="display: none"></d-progress-indicator>
+	</button>
 </body>
 </html>


### PR DESCRIPTION
- made Button a Container
- removed the part that trims innerText to fill in `label`
- set containerNode before the icon and the label
- I updated the samples (they were setting label using innerText) and added an example with a ProgressIndicator inside a ToggleButton.
- updated doc

> Quoted from doc: The only string displayed by the button is the one defined by its `label` property.

I took the liberty of removing this part of the doc, i think it's no longer relevant.
