### PR TITLE
modif samples : remove register.parse

### DIFF
--- a/samples/Combobox.html
+++ b/samples/Combobox.html
@@ -19,7 +19,6 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"dstore/Memory",
 			"deliteful/list/List",
 			"deliteful/Combobox",
@@ -29,8 +28,7 @@
 			"deliteful/Checkbox",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function (register, Memory, List) {
-			register.parse();
+		], function (Memory, List) {
 
 			startsWith.on("change", function () {
 				comboTeams.filterMode = "startsWith";

--- a/samples/Select.html
+++ b/samples/Select.html
@@ -19,14 +19,12 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"dstore/Memory",
 			"deliteful/Select",
 			"deliteful/Button",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function (register, Memory) {
-			register.parse();
+		], function (Memory) {
 
 			var storeTeams = new Memory({}),
 				storePlayers = new Memory({});

--- a/samples/SidePane-all.html
+++ b/samples/SidePane-all.html
@@ -18,13 +18,11 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/SidePane",
 			"deliteful/Button",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function(register){
-			register.parse();
+		], function(){
 			document.body.style.display = "";
 		});
 	</script>

--- a/samples/SidePane-overlay.html
+++ b/samples/SidePane-overlay.html
@@ -18,13 +18,11 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/SidePane",
 			"deliteful/Button",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function(register){
-			register.parse();
+		], function(){
 			document.body.style.display = "";
 		});
 	</script>

--- a/samples/SidePane-push.html
+++ b/samples/SidePane-push.html
@@ -18,13 +18,11 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/SidePane",
 			"deliteful/Button",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function(register){
-			register.parse();
+		], function(){
 			document.body.style.display = "";
 		});
 	</script>

--- a/samples/SidePane-reveal.html
+++ b/samples/SidePane-reveal.html
@@ -18,13 +18,11 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/SidePane",
 			"deliteful/Button",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function(register){
-			register.parse();
+		], function(){
 			document.body.style.display = "";
 		});
 	</script>

--- a/samples/Slider.html
+++ b/samples/Slider.html
@@ -18,12 +18,10 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/Slider",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function (register) {
-			register.parse();
+		], function () {
 
 			var slider = document.getElementById('sliderWidget');
 

--- a/samples/StarRating.html
+++ b/samples/StarRating.html
@@ -18,12 +18,10 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/StarRating",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function (register) {
-			register.parse();
+		], function () {
 			document.body.style.display = "";
 		});
 	</script>

--- a/samples/SwapView.html
+++ b/samples/SwapView.html
@@ -16,11 +16,10 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register", "deliteful/SwapView", "deliteful/ViewIndicator", "deliteful/Button",
+			"deliteful/SwapView", "deliteful/ViewIndicator", "deliteful/Button",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function (register) {
-			register.parse();
+		], function () {
 
 			var handle = function (event) {
 				console.log(event.type + ": " + event.dest);

--- a/samples/Switch.html
+++ b/samples/Switch.html
@@ -19,12 +19,10 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/Switch",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function (register, Switch) {
-			register.parse();
+		], function (Switch) {
 			document.body.style.display = "";
 		});
 	</script>

--- a/samples/ToggleButton.html
+++ b/samples/ToggleButton.html
@@ -18,12 +18,10 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/ToggleButton",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function (register) {
-			register.parse();
+		], function () {
 			document.body.style.display = "";
 		});
 	</script>

--- a/samples/ViewStack.html
+++ b/samples/ViewStack.html
@@ -16,7 +16,6 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/ViewStack",
 			"deliteful/Button",
 			"requirejs-dplugins/css!deliteful/ViewStack/transitions/cover.css",
@@ -27,8 +26,7 @@
 			"requirejs-dplugins/css!deliteful/ViewStack/transitions/revealv.css",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function(register){
-			register.parse();
+		], function(){
 
 			var handle = function(event){
 				console.log(event.type + ": " + event.dest);

--- a/samples/list/defaultStore-populate-decl.html
+++ b/samples/list/defaultStore-populate-decl.html
@@ -18,13 +18,11 @@
 
 	<script type="text/javascript">
 		require([
-		    "delite/register",
 			"deliteful/list/List",
 			"deliteful/Store",
 			"delite/theme!delite/themes/{{theme}}/global.css", // page level CSS
 			"requirejs-domready/domReady!"
-		], function (register) {
-			register.parse();
+		], function () {
 			document.body.style.display = "";
 		});
 	</script>

--- a/samples/list/header-list-footer.html
+++ b/samples/list/header-list-footer.html
@@ -18,14 +18,12 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"dstore/Memory",
 			"dstore/Trackable",
 			"deliteful/list/List",
 			"deliteful/LinearLayout",
 			"delite/theme!delite/themes/{{theme}}/global.css"	// page level CSS
-		], function (register, Memory, Trackable, List) {
-			register.parse();
+		], function (Memory, Trackable, List) {
 			var Store = Memory.createSubclass([Trackable], {});
 			list.store = new Store();
 			for (var i = 0; i < 50; i++) {

--- a/samples/list/navigationBetweenViews.html
+++ b/samples/list/navigationBetweenViews.html
@@ -31,7 +31,6 @@
 				"deliteful/Store",
 				"deliteful/list/List",
 				"requirejs-domready/domReady!"], function (keys) {
-				register.parse();
 				actionHandler = function(event) {
 					if ((event.type === "keydown" && event.keyCode === keys.SPACE) || event.type === "click") {
 						var renderer = event.currentTarget.getEnclosingRenderer(event.target);


### PR DESCRIPTION
I made the corrections on a part of the samples as asked in this issue : https://github.com/ibm-js/deliteful/issues/541
I have tested it on Chrome, Firefox, IE11, Safari (on iOS8) and Android (4.X).
I didn't find any regression.
There is however a problem on Android devices with Android browser where any tests is running (but works perfectly on Chrome for Android and Firefox).
Also one little problem on StarRating.html where green-man style doesn't work on Chrome for Android.