### PR TITLE
Removing calls to register.parse from samples and using deliver on functional tests

### DIFF
--- a/samples/Button.html
+++ b/samples/Button.html
@@ -18,12 +18,10 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/Button",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function (register) {
-			register.parse();
+		], function () {
 			document.body.style.display = "";
 		});
 	</script>
@@ -65,8 +63,8 @@
 <body style="display: none; background-color:white;">
 <div class="group">
 	<button is="d-button" label="Default button" onclick="alert(this.label + ' clicked.');"></button>
-	<button is="d-button" class="d-button-blue" label="Blue button" onclick="alert(this.label + ' clicked.');"></button>
-	<button is="d-button" class="d-button-red" label="Red button" onclick="alert(this.label + ' clicked.');"></button>
+	<button is="d-button" class="d-button-primary" label="Blue button" onclick="alert(this.label + ' clicked.');"></button>
+	<button is="d-button" class="d-button-danger" label="Red button" onclick="alert(this.label + ' clicked.');"></button>
 	<button is="d-button" iconClass = 'd-icon-phone' label="Custom with icon" class="d-button-green" onclick="alert(this.label + ' clicked.');"></button>
 	<button is="d-button" iconClass = 'd-icon-phone d-big-icon' label="Custom with icon" class="d-button-green" onclick="alert(this.label + ' clicked.');"></button>
 </div>

--- a/samples/Buttons.html
+++ b/samples/Buttons.html
@@ -23,31 +23,23 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/Checkbox",
 			"deliteful/Switch",
 			"deliteful/Button",
 			"deliteful/ToggleButton",
 			"deliteful/RadioButton",
 			"requirejs-domready/domReady!"
-		], function (register) {
-			register.parse();
+		], function () {
 			document.body.style.display = "";
 		});
 
 	</script>
 <style>
-	.d-icon-cut {
-		background-image: url('./images/paste.gif'); /* Contains both object and action icons in a sprite image for the enabled state.  */
-		width: 16px;
-		height: 16px;
-		background-repeat: no-repeat;
+	.d-icon-cut:before {
+		content: url('./images/paste.gif'); /* Contains both object and action icons in a sprite image for the enabled state.  */
 	}
-	.d-icon-copy {
-		background-image: url('./images/copy.gif'); /* Contains both object and action icons in a sprite image for the enabled state.  */
-		width: 16px;
-		height: 16px;
-		background-repeat: no-repeat;
+	.d-icon-copy:before {
+		content: url('./images/copy.gif'); /* Contains both object and action icons in a sprite image for the enabled state.  */
 	}
 	p {
 		line-height: 1.7em;

--- a/samples/Checkbox.html
+++ b/samples/Checkbox.html
@@ -19,12 +19,10 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/Checkbox",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function (register, Checkbox) {
-			register.parse();
+		], function () {
 			document.body.style.display = "";
 		});
 	</script>

--- a/samples/LinearLayout.html
+++ b/samples/LinearLayout.html
@@ -18,12 +18,10 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/LinearLayout",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function(register){
-			register.parse();
+		], function(){
 			document.body.style.display = "";
 		});
 	</script>

--- a/samples/ProgressBar-basic.html
+++ b/samples/ProgressBar-basic.html
@@ -18,12 +18,10 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/ProgressBar",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function (register) {
-			register.parse();
+		], function () {
 			document.body.style.display = "";
 		});
 	</script>

--- a/samples/ProgressBar-handler.html
+++ b/samples/ProgressBar-handler.html
@@ -18,13 +18,10 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/ProgressBar",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function (register) {
-			register.parse();
-
+		], function () {
 			var label = document.getElementById("lb");
 			var progressBar = document.getElementById("pb1");
 			var loadBtn = document.getElementById("loadBtn");

--- a/samples/ProgressBar-messages.html
+++ b/samples/ProgressBar-messages.html
@@ -18,13 +18,10 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/ProgressBar",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function (register) {
-			register.parse();
-
+		], function () {
 			var label = document.getElementById("lb");
 			var progressBar = document.getElementById("pb1");
 			var loadBtn = document.getElementById("loadBtn");

--- a/samples/ProgressIndicator-basic.html
+++ b/samples/ProgressIndicator-basic.html
@@ -17,12 +17,10 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/ProgressIndicator",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function (register, ProgressIndicator) {
-			register.parse();
+		], function () {
 			document.body.style.display = "";
 		});
 	</script>

--- a/samples/ProgressIndicator-overlay.html
+++ b/samples/ProgressIndicator-overlay.html
@@ -17,12 +17,10 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/ProgressIndicator",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function (register, ProgressIndicator) {
-			register.parse();
+		], function () {
 
 			var overlay = document.getElementById("overlay");
 			var progressIndicator = document.getElementById("pi");

--- a/samples/ProgressIndicator-percentage.html
+++ b/samples/ProgressIndicator-percentage.html
@@ -17,13 +17,10 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/ProgressIndicator",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function (register, ProgressIndicator) {
-			register.parse();
-
+		], function () {
 			var label = document.getElementById("lb");
 			var progressIndicator = document.getElementById("pi");
 			var loadBtn = document.getElementById("loadBtn");

--- a/samples/ResponsiveColumns.html
+++ b/samples/ResponsiveColumns.html
@@ -23,14 +23,11 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/LinearLayout",
 			"deliteful/ResponsiveColumns",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function(register){
-			register.parse();
-
+		], function(){
 			screenClassLabel.innerHTML = rc.screenClass;
 
 			document.body.style.display = "";

--- a/samples/ScrollableContainer.html
+++ b/samples/ScrollableContainer.html
@@ -19,12 +19,10 @@
 
 	<script type="text/javascript">
 		require([
-			"delite/register",
 			"deliteful/ScrollableContainer",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function(register){
-			register.parse();
+		], function(){
 			document.body.style.display = "";
 		});
 	</script>

--- a/tests/functional/Button.html
+++ b/tests/functional/Button.html
@@ -14,7 +14,7 @@
 		var ready = false; // set to true when the test page is ready
 		require(["delite/register", "deliteful/Button", "requirejs-domready/domReady!"],
 			function (register) {
-				register.parse();
+				register.deliver();
 				ready = true;
 			}
 		);

--- a/tests/functional/Checkbox.html
+++ b/tests/functional/Checkbox.html
@@ -14,7 +14,7 @@
 		var ready = false; // set to true when the test page is ready
 		require(["delite/register", "deliteful/Checkbox", "requirejs-domready/domReady!"],
 			function (register) {
-				register.parse();
+				register.deliver();
 				ready = true;
 			}
 		);

--- a/tests/functional/ScrollableContainer-alone-small.html
+++ b/tests/functional/ScrollableContainer-alone-small.html
@@ -22,7 +22,7 @@
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
 		], function(register){
-			register.parse();
+			register.deliver();
 			
 			scrollContainer1.on("scroll", function() {
 				console.log("scroll1");

--- a/tests/functional/ScrollableContainer-alone.html
+++ b/tests/functional/ScrollableContainer-alone.html
@@ -21,7 +21,7 @@
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
 		], function(register){
-			register.parse();
+			register.deliver();
 			
 			scrollContainer.on("scroll", function() {
 				console.log("scroll");

--- a/tests/functional/ScrollableContainer-full-screen-as-subchild-of-LinearLayout.html
+++ b/tests/functional/ScrollableContainer-full-screen-as-subchild-of-LinearLayout.html
@@ -21,7 +21,7 @@
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
 		], function(register){
-			register.parse();
+			register.deliver();
 			
 			scrollContainer.on("scroll", function() {
 				console.log("scroll");

--- a/tests/functional/ScrollableContainer-full-screen-as-subsubchild-of-LinearLayout.html
+++ b/tests/functional/ScrollableContainer-full-screen-as-subsubchild-of-LinearLayout.html
@@ -21,7 +21,7 @@
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
 		], function(register){
-			register.parse();
+			register.deliver();
 			
 			scrollContainer.on("scroll", function() {
 				console.log("scroll");

--- a/tests/functional/ScrollableContainer-full-screen.html
+++ b/tests/functional/ScrollableContainer-full-screen.html
@@ -21,7 +21,7 @@
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
 		], function(register){
-			register.parse();
+			register.deliver();
 			
 			scrollContainer.on("scroll", function() {
 				console.log("scroll");

--- a/tests/functional/ScrollableContainer-small.html
+++ b/tests/functional/ScrollableContainer-small.html
@@ -22,7 +22,7 @@
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
 		], function(register){
-			register.parse();
+			register.deliver();
 			
 			scrollContainer1.on("scroll", function() {
 				console.log("scroll1");

--- a/tests/functional/ScrollableContainer.html
+++ b/tests/functional/ScrollableContainer.html
@@ -24,7 +24,7 @@
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
 		], function (register) {
-			register.parse();
+			register.deliver();
 			
 			var reachedTop = false, reachedBottom = false,
 				reachedLeft = false, reachedRight = false;

--- a/tests/functional/SidePane.html
+++ b/tests/functional/SidePane.html
@@ -24,7 +24,7 @@
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
 		], function(register){
-			register.parse();
+			register.deliver();
 			ready = true;
 		});
 	</script>

--- a/tests/functional/StarRating-form.html
+++ b/tests/functional/StarRating-form.html
@@ -13,7 +13,7 @@
 			"requirejs-domready/domReady!"
 		], function(register, StarRating){
 
-			register.parse();
+			register.deliver();
 
  			// Create rating widget programmaticaly
 			var rating = new StarRating({

--- a/tests/functional/StarRating-formback.html
+++ b/tests/functional/StarRating-formback.html
@@ -12,7 +12,7 @@
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
 		], function(register){
-			register.parse();
+			register.deliver();
 			// Set global variable to signal that the test page is ready
 			ready = true;
 		})

--- a/tests/functional/StarRating.html
+++ b/tests/functional/StarRating.html
@@ -31,7 +31,7 @@
 			document.getElementById("value").innerHTML = val;
 		};
 
-		register.parse();
+		register.deliver();
 
 		// Create rating widget programmaticaly
 		var rating = new StarRating({

--- a/tests/functional/SwapView.html
+++ b/tests/functional/SwapView.html
@@ -15,7 +15,7 @@
 		require(["delite/register", "deliteful/SwapView", "deliteful/ViewIndicator",
 			"requirejs-domready/domReady!"],
 			function (register) {
-				register.parse();
+				register.deliver();
 				ready = true;
 			}
 		);

--- a/tests/functional/Switch.html
+++ b/tests/functional/Switch.html
@@ -17,7 +17,7 @@
 				"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 				"requirejs-domready/domReady!"
 				], function(register){
-					register.parse();
+					register.deliver();
 					ready = true;
 				});
 		

--- a/tests/functional/Toaster.html
+++ b/tests/functional/Toaster.html
@@ -39,7 +39,7 @@
 				"requirejs-domready/domReady!"
 				], function(register, ToasterMessage, Toaster){
 
-					register.parse();
+					register.deliver();
 
 					// Create Toaster widget pragmatically
 					toast = new Toaster({id: "default"});

--- a/tests/functional/slider/slider.html
+++ b/tests/functional/slider/slider.html
@@ -23,7 +23,7 @@
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
 		], function (register, Slider) {
-			register.parse();
+			register.deliver();
 			// read value from d-slider elements and set to span.innerHTML for intern functional test suite.
 			var nodeList = document.querySelectorAll("d-slider"), i;
 			for (i = 0; i < nodeList.length; ++i) {


### PR DESCRIPTION
Adaptation of some samples and tests to remove the register.parse calls and to use deliver instead of register on functional tests, as indicated in  [#541](https://github.com/ibm-js/deliteful/issues/541).

Tested on latest Chrome, Firefox and IE11 on desktop. Safari on iOS 8.1, Chrome, Firefox and default ("Internet") browser on Android 4.2.2 (Samsung Galaxy S4) and Chrome on Android 4.4 (Nexus  5).

On desktop: no regressions found except for a problem in a specific sample: "progressBar-handler.html". 
When the register.parse() call is removed, the error "progressBar.observe is not a function" is thrown one in two times. (Refers to [this line](https://github.com/ibm-js/deliteful/blob/f6b78d7be72068140e8c2d957ffc2e5ac4c080f1/samples/ProgressBar-handler.html#L62) )

Also, none of the samples runs on IE11. Apparently the problem is due to a change in the latest version of dcl (1.1.3) (Refers to [this commit](https://github.com/uhop/dcl/commit/b4b492c2f59aaef2dfec5830107cf0761fc484c1)). 
At that point f is the HTMLElement to register and that typeof HTMLElement usually returns "function", but in IE11 it returns "object". 

On iOs: no regression found.

On Android: 
4.4: works perfectly on Chrome.
4.2: works perfectly on Chrome and Firefox. but none of the samples works on the default ("Internet") browser. (even without removing the register.parse() call)