### PR TITLE
ToasterMessage: Timer is resumed on pointerup on touch devices

### DIFF
--- a/ToasterMessage.js
+++ b/ToasterMessage.js
@@ -224,17 +224,23 @@ define(["dcl/dcl",
 	var PauseTimerOnHover = function (element) {
 
 		var hovering = false;
-		function _pointerOverHandler() {
+		function _pauseTimer() {
 			if (!hovering) {
 				hovering = true;
 				element._timer.pause();
 			}
 		}
 
-		function _pointerLeaveHandler() {
+		function _resumeTimer() {
 			if (hovering) {
 				hovering = false;
 				element._timer.resume();
+			}
+		}
+
+		function _pointerUpHandler(e) {
+			if (e.pointerType === "touch") {
+				_resumeTimer();
 			}
 		}
 
@@ -242,9 +248,10 @@ define(["dcl/dcl",
 		var eventHandlers;
 		this.enable = function () {
 			this.isEnabled = true;
-			eventHandlers = [element.on("pointerover", _pointerOverHandler.bind(element)),
-				element.on("pointerleave", _pointerLeaveHandler.bind(element)),
-				element.on("pointercancel", _pointerLeaveHandler.bind(element))];
+			eventHandlers = [element.on("pointerover", _pauseTimer),
+				element.on("pointerleave", _resumeTimer),
+				element.on("pointercancel", _resumeTimer),
+				element.on("pointerup", _pointerUpHandler)];
 		};
 
 		this.disable = function () {

--- a/samples/Toaster.html
+++ b/samples/Toaster.html
@@ -24,7 +24,7 @@
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
 		], function (ToasterMessage, Toaster) {
-			window.toaster = new Toaster({placementClass: "d-toaster-placement-tr"});
+			window.toaster = new Toaster({placementClass: "d-toaster-placement-br"});
 			toaster.placeAt("body");
 			var timeout = 0;
 			var messages = [


### PR DESCRIPTION
For input devices that do not support hover, a pointerover event is fired before the pointerdown event, to avoid message who stay forever on the screen, the timer is resumed on pointerup when the pointer type is touch.


Note: on Window Phone 8.1 with IE11, when pointer is held pressed on the message, a pointerup is fired and the timer is resumed, due to the problem referenced on https://github.com/ibm-js/deliteful/issues/554

I changed messages placement to bottom rigth on toaster sample to have a better presentation on mobile devices.