### PR TITLE
deliteful/Select: workaround for issue in IE. Fixes #546

### DIFF
--- a/Select.js
+++ b/Select.js
@@ -221,6 +221,7 @@ define([
 		},
 		
 		refreshRendering: function (props) {
+			/* jshint maxcomplexity: 13 */
 			if ("renderItems" in props) {
 				// Populate the select with the items retrieved from the store.
 				var renderItems = this.renderItems;

--- a/Select.js
+++ b/Select.js
@@ -2,13 +2,14 @@
 define([
 	"dcl/dcl",
 	"requirejs-dplugins/jquery!attributes/classes",
+	"decor/sniff",
 	"delite/register",
 	"delite/FormWidget",
 	"delite/StoreMap",
 	"delite/Selection",
 	"delite/handlebars!./Select/Select.html",
 	"delite/theme!./Select/themes/{{theme}}/Select.css"
-], function (dcl, $, register,
+], function (dcl, $, register, has,
 	FormWidget, StoreMap, Selection, template) {
 
 	/**
@@ -251,6 +252,8 @@ define([
 						}
 						if (renderItem.value !== undefined) { // optional
 							option.setAttribute("value", renderItem.value);
+						} else if (has("ie")) { // #546
+							option.setAttribute("value", renderItem.text);
 						}
 						// The selection API (delite/Selection) needs to be called consistently
 						// for data items, not for render items.


### PR DESCRIPTION
See #546.

Workaround for IE's weird behavior when setting the `value` of an HTML `select` while its options do not have a `value` attribute. This seems to hold for IE 9, 10 and 11 (tested with IE11 and emulation of IE10 and IE9). 
I reproduced it in pure HTML here: http://jsfiddle.net/adrian_vasiliu/3x32dopL/. This contains 3 `<select>`. The first 2 do not have a `value` attribute on `<option>`, the 3rd has it. For the first select, select.selectedIndex is set: works fine. For the second, the `value` property is set: it works in Chrome/FF, but not in IE. For the third, the `value` property is set, and it works fine including in IE.

As far as I can see, this behavior in IE isn't correct, according to: 
* http://www.w3.org/TR/html5/forms.html#htmlselectelement says that select's `value` can be changed (is not readonly).
* http://www.w3.org/TR/html5/forms.html#the-option-element says that option's `value` defaults to its `text` attribute: "The value of an option element is the value of the value content attribute, if there is one, or, if there is not, the value of the element's text IDL attribute".
