### PR TITLE
overwrite itemUpdated in PageableList to adapt the index

### DIFF
--- a/list/PageableList.js
+++ b/list/PageableList.js
@@ -722,6 +722,18 @@ define([
 			};
 		}),
 
+		itemUpdated: dcl.superCall(function (sup) {
+			return function (index, item) {
+				if (this.pageLength > 0) {
+					if (this._firstLoaded < index && index <= this._lastLoaded) {
+						sup.call(this, index - this._firstLoaded, item);
+					}
+				} else {
+					sup.apply(this, arguments);
+				}
+			};
+		}),
+
 		_empty: dcl.superCall(function (sup) {
 			return function () {
 				sup.call(this, arguments);

--- a/tests/unit/list/PageableList.js
+++ b/tests/unit/list/PageableList.js
@@ -1011,6 +1011,26 @@ define([
 		"Add item to undisplayed page": function () {
 			return testHelpers["Helper: add item to undisplayed page"](this.async(3000), false);
 		},
+		"Update items in displayed page with index page > maxpages": function () {
+			var dfd = this.async(3000);
+			list = new PageableList({store: new Store()});
+			for (var i = 0; i < 20; i++) {
+				list.store.add({label: "item " + i, id: i});
+			}
+			list.pageLength = 5;
+			list.maxPages = 1;
+			document.body.appendChild(list);
+			list.attachedCallback();
+			// initial load (page 1 loaded)
+			list.deliver();
+			assertList(list, 0, 4, [], false, true, "assert 1");
+			clickNextPageLoader(list).then(dfd.callback(function () {
+				list.store.put({label: "item A", id: 6});
+				list.deliver();
+				assert.strictEqual(removeTabsAndReturns(list.children[2].textContent), "item A");
+			}));
+			return dfd;
+		},
 		"Reload list content": function () {
 			var dfd = this.async(3000);
 			list = new PageableList({store: new Store()});


### PR DESCRIPTION
Fix https://github.com/ibm-js/deliteful/issues/569.

PageableList was overwriting itemAdded and itemRemoved to adapt the index but did not overwrite itemUpdated.
