### PR TITLE
Fix styling issues when setting the width of the Combobox

### DIFF
--- a/Combobox/themes/Combobox_template.less
+++ b/Combobox/themes/Combobox_template.less
@@ -60,6 +60,7 @@
 	height: 100%;
 	vertical-align: inherit;
 	cursor: pointer;
+	width: 100%;
 	
 	/* Necessary for Safari on iOS to avoid misplacement of the dropdown arrow */
 	/* due to the presence of the hidden input which stores the submitted value.*/


### PR DESCRIPTION
When we set a CSS `width` property to the root element, the inside `<input>` does not respect its parents width and probably takes browser default. This is a base level issue irrespective of themes.

Incase more info is required, I can attach a screenshot!