### PR TITLE
Close/open combobox's popup while a filtering operation is in progress.

### DIFF
--- a/Combobox.js
+++ b/Combobox.js
@@ -576,7 +576,7 @@ define([
 		},
 
 		/**
-		 * Indicates if a filterin operation is in progress. If so, closeDropDown will perform differently than usual.
+		 * Indicates if a filtering operation is in progress. If so, closeDropDown will perform differently than usual.
 		 * @member {boolean}
 		 * @default false
 		 */

--- a/Combobox.js
+++ b/Combobox.js
@@ -589,13 +589,13 @@ define([
 				// events, triggered when pressing ENTER. This would also fit for Chrome/Android,
 				// where pressing the search key of the virtual keyboard also triggers a
 				// change event. But there's no equivalent on Safari / iOS...
-				if(this.opened && !this.filteringInProgress) {
+				if (this.opened && !this.filteringInProgress) {
 					this.filteringInProgress = true;
 					this.closeDropDown();
 				}
 				// this.filter() call will fire a query-success event. After that, the popup can be opened again.
 				this.own(this.list.on("query-success", function () {
-					if(this.filteringInProgress) {
+					if (this.filteringInProgress) {
 						this.filteringInProgress = false;
 						this.openDropDown();
 					}

--- a/samples/Combobox.html
+++ b/samples/Combobox.html
@@ -40,7 +40,7 @@
 			ignoreCase.on("change", function () {
 				comboTeams.ignoreCase = ignoreCase.checked;
 			});
-		
+
 			showResults = function () {
 				var getSelectedItemsTxt = function (combobox) {
 					var res = "", noOptionSelected = "no option selected";
@@ -58,7 +58,7 @@
 					}
 					return res;
 				};
-				alert("Thanks for filling the form!\n" + 
+				alert("Thanks for filling the form!\n" +
 					"Your favorite team: " + getSelectedItemsTxt(comboTeams) +
 					"\nYour favorite players: " + getSelectedItemsTxt(comboPlayers));
 			};
@@ -66,7 +66,7 @@
 			document.body.style.display = "";
 		});
 	</script>
-	
+
 	<style>
 	html {
 		margin: 5px;
@@ -82,7 +82,7 @@
 <label for="comboTeams-input">Your favorite team (single choice):</label>
 </p>
 <d-combobox selectionMode="single" autoFilter="true" id="comboTeams">
-	<d-list righttextAttr="world-cup-victories" categoryAttr="region">
+	<d-list righttextAttr="world-cup-victories" categoryAttr="region" showNoItems="true">
 		{ "label": "France", "world-cup-victories": 1, "region": "EU" },
 		{ "label": "Germany", "world-cup-victories": 4, "region": "EU" },
 		{ "label": "Spain", "world-cup-victories": 1, "region": "EU" },

--- a/tests/functional/ComboPopup.html
+++ b/tests/functional/ComboPopup.html
@@ -191,7 +191,7 @@
 		Combobox popup with &lt;input&gt; (autoFilter=true)
 	</label>
 	<d-combobox selectionMode="single" autoFilter="true" id="combo2" name="combo2">
-		<d-list righttextAttr="sales" categoryAttr="region">
+		<d-list righttextAttr="sales" categoryAttr="region" showNoItems="true">
 			{ "label": "France", "sales": 500, "profit": 50, "region": "EU" },
 			{ "label": "Germany", "sales": 450, "profit": 48, "region": "EU" },
 			{ "label": "UK", "sales": 700, "profit": 60, "region": "EU" },

--- a/tests/functional/Combobox-decl.html
+++ b/tests/functional/Combobox-decl.html
@@ -147,9 +147,7 @@
 			moveToBottom = function (comboId) {
 				var viewport = Viewport.getEffectiveBox();
 				var bottomNode = document.getElementById("bottomNode");
-				bottomNode.style.cssText =
-				"position: absolute; width: 20px; height: 20px; background: yellow; left: 0; top: " +
-				(viewport.h + 80) + "px";
+				bottomNode.style.cssText = "position: fixed; bottom: 0;"
 				document.getElementById(comboId).placeAt(bottomNode);
 			}
 

--- a/tests/functional/Combobox-decl.html
+++ b/tests/functional/Combobox-decl.html
@@ -128,6 +128,21 @@
 				};
 			};
 
+			isAligned = function (comboId, pos) {
+				var combo = document.getElementById(comboId);
+				var popup = document.getElementById(comboId +  "_dropdown_wrapper");
+				var comboClientRect = combo.getBoundingClientRect();
+				var popupClientRect = popup.getBoundingClientRect();
+
+				return {
+					popup: popupClientRect,
+					combo: comboClientRect,
+					isAligned: (pos === "below") ?
+						(Math.abs(comboClientRect.bottom - popupClientRect.top) <= 3 ? true : false) :
+						(Math.abs(comboClientRect.top - popupClientRect.bottom) <= 3 ? true : false)
+				}
+			}
+
 			ready = true;
 		});
 	</script>

--- a/tests/functional/Combobox-decl.html
+++ b/tests/functional/Combobox-decl.html
@@ -20,13 +20,14 @@
 
 		require([
 			"delite/register",
+			"delite/Viewport",
 			"deliteful/list/List",
 			"deliteful/Combobox",
 			"deliteful/RadioButton",
 			"deliteful/Checkbox",
 			"delite/theme!delite/themes/{{theme}}/global.css", // page level CSS
 			"requirejs-domready/domReady!"
-		], function (register) {
+		], function (register, Viewport) {
 			register.deliver();
 
 			startsWith.on("change", function () {
@@ -138,9 +139,18 @@
 					popup: popupClientRect,
 					combo: comboClientRect,
 					isAligned: (pos === "below") ?
-						(Math.abs(comboClientRect.bottom - popupClientRect.top) <= 3 ? true : false) :
-						(Math.abs(comboClientRect.top - popupClientRect.bottom) <= 3 ? true : false)
+						Math.abs(comboClientRect.bottom - popupClientRect.top) <= 3 :
+						Math.abs(comboClientRect.top - popupClientRect.bottom) <= 3
 				}
+			};
+
+			moveToBottom = function (comboId) {
+				var viewport = Viewport.getEffectiveBox();
+				var bottomNode = document.getElementById("bottomNode");
+				bottomNode.style.cssText =
+				"position: absolute; width: 20px; height: 20px; background: yellow; left: 0; top: " +
+				(viewport.h + 80) + "px";
+				document.getElementById(comboId).placeAt(bottomNode);
 			}
 
 			ready = true;
@@ -680,6 +690,6 @@
 	<input id="submitB" type="submit">
 </fieldset>
 </form>
-
+<div id="bottomNode"></div>
 </body>
 </html>

--- a/tests/functional/Combobox.js
+++ b/tests/functional/Combobox.js
@@ -851,18 +851,6 @@ define([
 			.execute(comboId + ".closeDropDown();");
 	};
 
-	/*var checkPopupPosition = function (remote, comboId, position) {
-		return loadFile(remote, "./Combobox-decl.html")
-			.findById(comboId)
-			.click() // opens popup
-			.sleep(500)
-			.execute("return isAligned(\"" + comboId + "\", \"" + position + "\")")
-			.then(function (value) {
-				assert.isTrue(value.isAligned, comboId + "'s popup is not aligned as expected.");
-			})
-			.end();
-	};*/
-
 	var checkPopupPosition = function (remote, comboId, position) {
 		return loadFile(remote, "./Combobox-decl.html")
 			.execute("return moveToBottom(\"" + comboId + "\");")

--- a/tests/functional/Combobox.js
+++ b/tests/functional/Combobox.js
@@ -851,6 +851,51 @@ define([
 			.execute(comboId + ".closeDropDown();");
 	};
 
+	var checkPopupPosition = function (remote, comboId, position) {
+		return loadFile(remote, "./Combobox-decl.html")
+			.findById(comboId)
+			.click() // opens popup
+			.sleep(500)
+			.execute("return isAligned(\"" + comboId + "\", \"" + position + "\")")
+			.then(function (value) {
+				assert.strictEqual(value.isAligned, true, comboId + "'s popup is not aligned as expected.");
+			})
+			.end();
+	};
+
+	var checkPopupPositionAfterFilter = function (remote, comboId, position) {
+		return loadFile(remote, "./Combobox-decl.html")
+			.findById(comboId)
+			.click() // opens popup
+			.sleep(500)
+			.execute("return isAligned(\"" + comboId + "\", \"above\")")
+			.then(function (value) {
+				assert.strictEqual(value.isAligned, true, comboId + "'s popup is not aligned as expected.");
+			})
+			.pressKeys(keys.BACKSPACE) // Delete the 2 chars of "France" -> "Fran"
+			.pressKeys(keys.BACKSPACE)
+			.execute("return isAligned(\"" + comboId + "\", \"above\")")
+			.then(function (value) {
+				assert.strictEqual(value.isAligned, true, comboId + "'s popup is not aligned as expected.");
+			})
+			.pressKeys(keys.BACKSPACE)
+			.pressKeys(keys.BACKSPACE)
+			.pressKeys(keys.BACKSPACE)
+			.pressKeys(keys.BACKSPACE) // input field cleared.
+			.pressKeys("c")
+			.execute("return isAligned(\"" + comboId + "\", \"above\")")
+			.then(function (value) {
+				assert.strictEqual(value.isAligned, true, comboId + "'s popup is not aligned as expected.");
+			})
+			.pressKeys(keys.BACKSPACE) // input field cleared.
+			.pressKeys("fake input") // empy list returned.
+			.execute("return isAligned(\"" + comboId + "\", \"below\")")
+			.then(function (value) {
+				assert.strictEqual(value.isAligned, true, comboId + "'s popup is not aligned as expected.");
+			})
+			.end();
+	};
+
 	registerSuite({
 		name: "Combobox - functional",
 
@@ -980,6 +1025,45 @@ define([
 				return this.skip("click() doesn't generate touchstart/touchend, so popup won't open");
 			}
 			return checkMouseNavigationMultipleSelection(remote, "combo3");
+		},
+
+		"popup is below" : function () {
+			var remote = this.remote;
+			if (remote.environmentType.browserName === "internet explorer") {
+				// https://github.com/theintern/leadfoot/issues/17
+				return this.skip("click() doesn't generate mousedown/mouseup, so popup won't open");
+			}
+			if (remote.environmentType.platformName === "iOS") {
+				// https://github.com/theintern/leadfoot/issues/61
+				return this.skip("click() doesn't generate touchstart/touchend, so popup won't open");
+			}
+			return checkPopupPosition(remote, "combo1", "below");
+		},
+
+		"popup is above": function () {
+			var remote = this.remote;
+			if (remote.environmentType.browserName === "internet explorer") {
+				// https://github.com/theintern/leadfoot/issues/17
+				return this.skip("click() doesn't generate mousedown/mouseup, so popup won't open");
+			}
+			if (remote.environmentType.platformName === "iOS") {
+				// https://github.com/theintern/leadfoot/issues/61
+				return this.skip("click() doesn't generate touchstart/touchend, so popup won't open");
+			}
+			return checkPopupPosition(remote, "combo1-value", "above");
+		},
+
+		"popup position after filter": function () {
+			var remote = this.remote;
+			if (remote.environmentType.browserName === "internet explorer") {
+				// https://github.com/theintern/leadfoot/issues/17
+				return this.skip("click() doesn't generate mousedown/mouseup, so popup won't open");
+			}
+			if (remote.environmentType.platformName === "iOS") {
+				// https://github.com/theintern/leadfoot/issues/61
+				return this.skip("click() doesn't generate touchstart/touchend, so popup won't open");
+			}
+			return checkPopupPositionAfterFilter(remote, "combo1-value");
 		}
 	});
 });

--- a/tests/functional/Combobox.js
+++ b/tests/functional/Combobox.js
@@ -851,47 +851,42 @@ define([
 			.execute(comboId + ".closeDropDown();");
 	};
 
-	var checkPopupPosition = function (remote, comboId, position) {
+	/*var checkPopupPosition = function (remote, comboId, position) {
 		return loadFile(remote, "./Combobox-decl.html")
 			.findById(comboId)
 			.click() // opens popup
 			.sleep(500)
 			.execute("return isAligned(\"" + comboId + "\", \"" + position + "\")")
 			.then(function (value) {
-				assert.strictEqual(value.isAligned, true, comboId + "'s popup is not aligned as expected.");
+				assert.isTrue(value.isAligned, comboId + "'s popup is not aligned as expected.");
 			})
 			.end();
-	};
+	};*/
 
-	var checkPopupPositionAfterFilter = function (remote, comboId, position) {
+	var checkPopupPosition = function (remote, comboId, position) {
 		return loadFile(remote, "./Combobox-decl.html")
+			.execute("return moveToBottom(\"" + comboId + "\");")
 			.findById(comboId)
 			.click() // opens popup
 			.sleep(500)
-			.execute("return isAligned(\"" + comboId + "\", \"above\")")
+			.execute("return isAligned(\"" + comboId + "\", \"" + position + "\")")
 			.then(function (value) {
-				assert.strictEqual(value.isAligned, true, comboId + "'s popup is not aligned as expected.");
+				assert.isTrue(value.isAligned, comboId + "'s popup is not aligned as expected.");
 			})
 			.pressKeys(keys.BACKSPACE) // Delete the 2 chars of "France" -> "Fran"
 			.pressKeys(keys.BACKSPACE)
-			.execute("return isAligned(\"" + comboId + "\", \"above\")")
+			.execute("return isAligned(\"" + comboId + "\", \"" + position + "\")")
 			.then(function (value) {
-				assert.strictEqual(value.isAligned, true, comboId + "'s popup is not aligned as expected.");
+				assert.isTrue(value.isAligned, comboId + "'s popup is not aligned as expected.");
 			})
 			.pressKeys(keys.BACKSPACE)
 			.pressKeys(keys.BACKSPACE)
 			.pressKeys(keys.BACKSPACE)
 			.pressKeys(keys.BACKSPACE) // input field cleared.
-			.pressKeys("c")
-			.execute("return isAligned(\"" + comboId + "\", \"above\")")
+			.pressKeys("c") // Canada & China as result.
+			.execute("return isAligned(\"" + comboId + "\", \"" + position + "\")")
 			.then(function (value) {
-				assert.strictEqual(value.isAligned, true, comboId + "'s popup is not aligned as expected.");
-			})
-			.pressKeys(keys.BACKSPACE) // input field cleared.
-			.pressKeys("fake input") // empy list returned.
-			.execute("return isAligned(\"" + comboId + "\", \"below\")")
-			.then(function (value) {
-				assert.strictEqual(value.isAligned, true, comboId + "'s popup is not aligned as expected.");
+				assert.isTrue(value.isAligned, comboId + "'s popup is not aligned as expected.");
 			})
 			.end();
 	};
@@ -1027,32 +1022,6 @@ define([
 			return checkMouseNavigationMultipleSelection(remote, "combo3");
 		},
 
-		"popup is below" : function () {
-			var remote = this.remote;
-			if (remote.environmentType.browserName === "internet explorer") {
-				// https://github.com/theintern/leadfoot/issues/17
-				return this.skip("click() doesn't generate mousedown/mouseup, so popup won't open");
-			}
-			if (remote.environmentType.platformName === "iOS") {
-				// https://github.com/theintern/leadfoot/issues/61
-				return this.skip("click() doesn't generate touchstart/touchend, so popup won't open");
-			}
-			return checkPopupPosition(remote, "combo1", "below");
-		},
-
-		"popup is above": function () {
-			var remote = this.remote;
-			if (remote.environmentType.browserName === "internet explorer") {
-				// https://github.com/theintern/leadfoot/issues/17
-				return this.skip("click() doesn't generate mousedown/mouseup, so popup won't open");
-			}
-			if (remote.environmentType.platformName === "iOS") {
-				// https://github.com/theintern/leadfoot/issues/61
-				return this.skip("click() doesn't generate touchstart/touchend, so popup won't open");
-			}
-			return checkPopupPosition(remote, "combo1-value", "above");
-		},
-
 		"popup position after filter": function () {
 			var remote = this.remote;
 			if (remote.environmentType.browserName === "internet explorer") {
@@ -1063,7 +1032,7 @@ define([
 				// https://github.com/theintern/leadfoot/issues/61
 				return this.skip("click() doesn't generate touchstart/touchend, so popup won't open");
 			}
-			return checkPopupPositionAfterFilter(remote, "combo1-value");
+			return checkPopupPosition(remote, "combo2-custom-sel-single", "above");
 		}
 	});
 });


### PR DESCRIPTION
This PR closes and opens the dropdown before and right after a filtering operation has performed, allowing so to calculate again size and position of the popup wrapper. 

Moreover, it updates samples and tests page in order to leverage on List's `showNoItems` feature, when the query returns an empty set. It may be worth to set this feature by default. Of course it makes sense only when `autoFilter=true`.