### PR TITLE
Combobox: multiple fixes.

### DIFF
--- a/Combobox.js
+++ b/Combobox.js
@@ -984,6 +984,7 @@ define([
 						}
 						this.dropDown.focus();
 					}
+
 				}.bind(this));
 			};
 		}),

--- a/Combobox.js
+++ b/Combobox.js
@@ -746,7 +746,7 @@ define([
 					if (this.opened) {
 						this.closeDropDown(true/*refocus*/);
 					}
-				} else if (evt.key === "Spacebar") {
+				} else if (evt.key === "Spacebar" && this.opened) {
 					// Simply forwarding the key event to List doesn't allow toggling
 					// the selection, because List's mechanism is based on the event target
 					// which here is the input element outside the List. TODO: see deliteful #500.

--- a/Combobox.js
+++ b/Combobox.js
@@ -1033,6 +1033,9 @@ define([
 			// Since List is in focus-less mode, it does not give focus to
 			// navigated items, thus the browser does not autoscroll.
 			// TODO: see deliteful #498
+			if (!item) {
+				item = this.list.navigatedDescendant;
+			}
 
 			if (!item) {
 				var selectedItems = this.list.selectedItems;

--- a/Combobox.js
+++ b/Combobox.js
@@ -539,6 +539,8 @@ define([
 								}
 							}.bind(this), 100); // worth exposing a property for the delay?
 						}
+					} else {
+						this.focusNode.focus(); // put the focus back to the inputNode.
 					}
 				}.bind(this)),
 

--- a/Combobox.js
+++ b/Combobox.js
@@ -669,8 +669,11 @@ define([
 				// inputNode does not contain text
 				if (!this.hasDownArrow) {
 					// in auto complete mode
-					this.closeDropDown();
-					this._toggleComboPopupList();
+					if (this._isMobile) {
+						this._toggleComboPopupList();
+					} else {
+						this.closeDropDown();
+					}
 					return false;
 				}
 			}

--- a/Combobox.js
+++ b/Combobox.js
@@ -204,7 +204,10 @@ define([
 		list: null,
 
 		// Flag used for binding the readonly attribute of the input element in the template
-		_inputReadOnly: true,
+		_inputReadOnly: false,
+
+		// Flag used to track when the inputNode has to be updated in order to set the readonly attribute.
+		_updateInputReadOnly: false,
 
 		/**
 		 * The value of the placeholder attribute of the input element used
@@ -295,6 +298,8 @@ define([
 		// Flag used for post initializing the widget value, if the list has not been created yet.
 		_processValueAfterListInit: false,
 
+		_isMobile: !!ComboPopup,
+
 		createdCallback: function () {
 			// Declarative case (list specified declaratively inside the declarative Combobox)
 			var list = this.querySelector("d-list");
@@ -312,14 +317,14 @@ define([
 
 			this.on("click", function () {
 				// NOTE: This runs only when in mobile mode
-				if (this._useCenteredDropDown() && !this.disabled) {
+				if (this._isMobile && !this.disabled) {
 					this.openDropDown();
 				}
 			}.bind(this));
 
 			this.on("mousedown", function (evt) {
 				// NOTE: This runs only when in desktop mode
-				if (!this._useCenteredDropDown() && (!this.minFilterChars || this._inputReadOnly)) {
+				if (!this._isMobile && (!this.minFilterChars || this._inputReadOnly)) {
 					// event could be triggered by the down arrow element. If so, we do not react to it.
 					if (evt.srcElement !== this.buttonNode && !this.disabled) {
 						if (!this.opened) {
@@ -381,25 +386,39 @@ define([
 
 		/* jshint maxcomplexity: 17 */
 		refreshRendering: function (oldValues) {
-			var updateReadOnly = false;
 			if ("list" in oldValues && this.list) {
 				this._initList();
 			}
 			if ("selectionMode" in oldValues) {
-				updateReadOnly = true;
 				if (this.list) {
 					this.list.selectionMode = this.selectionMode === "single" ?
 						"radio" : "multiple";
 				}
 			}
-			if ("autoFilter" in oldValues ||
-				"readOnly" in oldValues) {
-				updateReadOnly = true;
+			if ("autoFilter" in oldValues || "selectionMode" in oldValues ||
+				"readOnly" in oldValues || "source" in oldValues || "_updateInputReadOnly" in oldValues) {
+				this._updateInputReadOnly = false;
+
+				this._inputReadOnly = this.hasDownArrow ? this._isSourceEmpty() ||
+					this.readOnly || !this.autoFilter || this.selectionMode === "multiple" : false;
+
+				this.inputNode.readOnly = this._inputReadOnly || this._isMobile ? "readonly" : "";
+
+				if (this._inputReadOnly) {
+					this.inputNode.setAttribute("unselectable", "on");
+					$(this.inputNode)
+						.css("user-select", "none") // maps to WebkitUserSelect, etc.
+						.on("selectstart", false);
+				} else {
+					this.inputNode.removeAttribute("unselectable");
+					$(this.inputNode)
+						.css("user-select", "") // maps to WebkitUserSelect, etc.
+						.off("selectstart", false);
+				}
 			}
-			if (updateReadOnly) {
-				this._updateInputReadOnly();
-				this._setSelectable(this.inputNode, !this.inputNode.readOnly);
-			}
+		},
+
+		computeProperties: function (oldValues) {
 			if ("value" in oldValues) {
 				if (!this._justValidated) {
 					if (this.list) {
@@ -415,48 +434,6 @@ define([
 				if (this._justValidated) {
 					this._justValidated = false;
 				}
-			}
-			if ("displayedValue" in oldValues) {
-				this.inputNode.value = this.displayedValue;
-			}
-		},
-
-		/**
-		 * Updates the value of the private property on which the Combobox template
-		 * binds the `readonly` attribute of the input element.
-		 * @private
-		 */
-		_updateInputReadOnly: function () {
-			var oldValue = this._inputReadOnly;
-			this._inputReadOnly = this.readOnly || !this.autoFilter ||
-				this._useCenteredDropDown() || this.selectionMode === "multiple";
-			if (this._inputReadOnly === oldValue) {
-				// FormValueWidget.refreshRendering() mirrors the value of widget.readOnly
-				// to focusNode.readOnly, thus competing with the binding of the readOnly
-				// attribute of the input node (which is also the focusNode attach point)
-				// in the template of Combobox. To ensure the refresh of the binding is done
-				// including when the value of the flag _inputReadOnly doesn't change while
-				// FormValueWidget has reset the attribute to a different value, force
-				// the notification:
-				this.notifyCurrentValue("_inputReadOnly");
-			} // else no need to notify "by hand", rely on automatic notification
-		},
-
-		/**
-		 * Configures inputNode such that the text is selectable or unselectable.
-		 * @private
-		 */
-		_setSelectable: function (inputNode, selectable) {
-			if (selectable) {
-				inputNode.removeAttribute("unselectable");
-				$(inputNode)
-					.css("user-select", "") // maps to WebkitUserSelect, etc.
-					.off("selectstart", false);
-			} else {
-				inputNode.setAttribute("unselectable", "on");
-				$(inputNode)
-					.css("user-select", "none") // maps to WebkitUserSelect, etc.
-					.on("selectstart", false);
 			}
 		},
 
@@ -550,6 +527,14 @@ define([
 					this.handleOnInput(this.value); // emit "input" event
 				}.bind(this)),
 
+				this.list.observe(function (oldValues) {
+					if ("renderItems" in oldValues) {
+						// if the source changes, we may have to update the
+						// inputNode's readOnly attribute
+						this._updateInputReadOnly = true;
+					}
+				}.bind(this)),
+
 				this.list.on("query-success", this._setSelectedItems.bind(this))
 			];
 		},
@@ -596,19 +581,16 @@ define([
 		 * on the channel has() features set by `deliteful/features`.
 		 * @private
 		 */
-		_useCenteredDropDown: function () {
-			return !!ComboPopup;
-		},
+		// _useCenteredDropDown: function () {
+		// 	return !!ComboPopup;
+		// },
 
 		loadDropDown: function () {
-			this._updateInputReadOnly();
-
-			var centeredDropDown = this._useCenteredDropDown();
-			var dropDown = centeredDropDown ?
+			var dropDown = this._isMobile ?
 				this.createCenteredDropDown() :
 				this.createAboveBelowDropDown();
 
-			this.dropDownPosition = centeredDropDown ?
+			this.dropDownPosition = this._isMobile ?
 				["center"] :
 				["below", "above"]; // this is the default
 
@@ -658,12 +640,13 @@ define([
 		 * @return {boolean}
 		 */
 		shouldRunQuery: function (inputElement) {
-			var mobile = this._useCenteredDropDown();
 			if (inputElement.value.length !== 0) {
 				// inputNode contains text
 				if (inputElement.value.length < this.minFilterChars) {
-					if (!mobile) {
+					if (!this._isMobile) {
 						this.closeDropDown();
+					} else {
+						this._toggleComboPopupList();
 					}
 					return false;
 				}
@@ -688,7 +671,8 @@ define([
 		_toggleComboPopupList: function () {
 			if (this._isMobile) {
 				this.list.setAttribute("d-shown",
-					"" + this.dropDown.inputNode.value.length >= this.minFilterChars);
+					"" + (this.dropDown.inputNode.value.length !== 0 &&
+					this.dropDown.inputNode.value.length >= this.minFilterChars));
 				this.list.emit("delite-size-change");
 			}
 		},
@@ -711,7 +695,7 @@ define([
 
 				// save what user typed at each keystroke.
 				this.value = inputElement.value;
-				if (this._useCenteredDropDown()) {
+				if (this._isMobile) {
 					this.displayedValue = inputElement.value;
 				}
 				this.handleOnInput(this.value); // emit "input" event.
@@ -769,7 +753,7 @@ define([
 				} else if (evt.key === "ArrowDown" || evt.key === "ArrowUp" ||
 					evt.key === "PageDown" || evt.key === "PageUp" ||
 					evt.key === "Home" || evt.key === "End") {
-					if (this._useCenteredDropDown()) {
+					if (this._isMobile) {
 						this.list.emit("keydown", evt);
 					}
 					evt.stopPropagation();
@@ -796,7 +780,7 @@ define([
 				this.displayedValue = selectedItem ? this._getItemLabel(selectedItem) : "";
 				this.value = selectedItem ? this._getItemValue(selectedItem) : "";
 			} else {
-				var item = this._retrieveItemFromSource(this.value);
+				var item = this.hasDownArrow ? this._retrieveItemFromSource(this.value) : null;
 				this.displayedValue = item ? item[this.list.labelAttr || this.list.labelFunc] : this.value;
 			}
 		},
@@ -841,7 +825,7 @@ define([
 				if (n > 1) {
 					this.displayedValue = string.substitute(this.multipleChoiceMsg, {items: n});
 				} else if (n === 1) {
-					var item = this._retrieveItemFromSource(items[0]);
+					var item = this.hasDownArrow ? this._retrieveItemFromSource(items[0]) : null;
 					this.displayedValue = item ? item[this.list.labelAttr || this.list.labelFunc] : this.value;
 				} else {
 					this.displayedValue = this.multipleChoiceNoSelectionMsg;
@@ -947,12 +931,10 @@ define([
 				this._setSelectedItems();
 
 				if (!this.opened) {
-					var mobile = this._useCenteredDropDown();
-
 					// On desktop, leave focus in the original <input>.  But on mobile, focus the popup dialog.
-					this.focusOnPointerOpen = this.focusOnKeyboardOpen = mobile;
+					this.focusOnPointerOpen = this.focusOnKeyboardOpen = this._isMobile;
 
-					if (!mobile) {
+					if (!this._isMobile) {
 						this.defer(function () {
 							// Avoid losing focus when clicking the arrow (instead of the input element):
 							// TODO: isn't this already handled by delite/HasDropDown#_dropDownPointerUpHandler() ?
@@ -967,21 +949,22 @@ define([
 					// Avoid that List gives focus to list items when navigating, which would
 					// blur the input field used for entering the filtering criteria.
 					this.dropDown.focusDescendants = false;
-					if (!this._useCenteredDropDown()) {
+					if (!this._isMobile) {
 						// desktop version
 						this._updateScroll(undefined, true);	// sets this.list.navigatedDescendant
 						this._setActiveDescendant(this.list.navigatedDescendant);
 					} else {
 						// mobile version
+						// INFO: display into the popup's inputNode any pre-selected item or typed text,
+						// only if the inputNode is visible, though.
+						if (!this._inputReadOnly) {
+							this.dropDown.inputNode.value = this.displayedValue;
+						}
+
 						if (!this.hasDownArrow) {
 							this._toggleComboPopupList();
-						} else {
-							// INFO: display into the popup inputNode any pre-selected item,
-							// only if the inputNode is visible, though.
-							if (!this._inputReadOnly) {
-								this.dropDown.inputNode.value = this.displayedValue;
-							}
 						}
+
 						this.dropDown.focus();
 					}
 
@@ -1068,6 +1051,18 @@ define([
 				var input = this._popupInput || this.inputNode;
 				input.setAttribute("aria-activedescendant", nd.id);
 			}
+		},
+
+		_isSourceEmpty: function () {
+			var _source = (this.list && this.list.source) || this.source;
+			if (_source) {
+				if (Array.isArray(_source)) {
+					return _source.length === 0;
+				}
+				// not an array.
+				return _source.data && _source.data.length === 0;
+			}
+			return true;
 		}
 	});
 });

--- a/Combobox.js
+++ b/Combobox.js
@@ -684,8 +684,9 @@ define([
 		 * Toggles the list's visibility when ComboPopup is used (so in mobile)
 		 */
 		_toggleComboPopupList: function () {
-			if (this._useCenteredDropDown()) {
-				this.list.setAttribute("d-shown", "" + this.inputNode.value.length >= this.minFilterChars);
+			if (this._isMobile) {
+				this.list.setAttribute("d-shown",
+					"" + this.dropDown.inputNode.value.length >= this.minFilterChars);
 				this.list.emit("delite-size-change");
 			}
 		},
@@ -972,6 +973,12 @@ define([
 						// mobile version
 						if (!this.hasDownArrow) {
 							this._toggleComboPopupList();
+						} else {
+							// INFO: display into the popup inputNode any pre-selected item,
+							// only if the inputNode is visible, though.
+							if (!this._inputReadOnly) {
+								this.dropDown.inputNode.value = this.displayedValue;
+							}
 						}
 						this.dropDown.focus();
 					}

--- a/Combobox/ComboPopup.html
+++ b/Combobox/ComboPopup.html
@@ -1,8 +1,9 @@
 <template role="presentation"
 	requires="deliteful/LinearLayout, deliteful/Button">
 	<d-linear-layout style="height: 100%">
-        <div class="d-combo-popup-header">{{header}}</div>
+        <div class="d-combo-popup-header" id="{{_tag}}-{{widgetId}}-header">{{header}}</div>
 		<input d-hidden="{{this.combobox._inputReadOnly}}"
+			aria-labelledby="{{_tag}}-{{widgetId}}-header"
 			attach-point="inputNode"
 			class="d-combobox-input"
 			role="combobox" autocomplete="off" autocapitalize="none" autocorrect="off"

--- a/Combobox/ComboPopup.html
+++ b/Combobox/ComboPopup.html
@@ -2,7 +2,7 @@
 	requires="deliteful/LinearLayout, deliteful/Button">
 	<d-linear-layout style="height: 100%">
         <div class="d-combo-popup-header">{{header}}</div>
-		<input d-hidden="{{!(this.combobox.autoFilter && this.combobox.selectionMode !== 'multiple')}}"
+		<input d-hidden="{{this.combobox._inputReadOnly}}"
 			attach-point="inputNode"
 			class="d-combobox-input"
 			role="combobox" autocomplete="off" autocapitalize="none" autocorrect="off"

--- a/Combobox/ComboPopup.js
+++ b/Combobox/ComboPopup.js
@@ -58,6 +58,11 @@ define([
 							.removeClass("d-hidden");
 					}
 					this.combobox._prepareInput(this.inputNode);
+					this.combobox.observe(function (oldValues) {
+						if ("opened" in oldValues) {
+							this.inputNode.setAttribute("aria-expanded", this.combobox.opened);
+						}
+					}.bind(this));
 				}
 			}
 		},

--- a/Combobox/ComboPopup.js
+++ b/Combobox/ComboPopup.js
@@ -88,7 +88,7 @@ define([
 		 * @protected
 		 */
 		focus: function () {
-			if (this.combobox.autoFilter && this.combobox.selectionMode === "single") {
+			if (!this.combobox._inputReadOnly) {
 				this.inputNode.focus();
 			} else {
 				// first check if list is not hidden.
@@ -97,7 +97,7 @@ define([
 					var id = this.combobox.list.getIdentity(
 						this.combobox.list.selectedItems.length > 0 ? this.combobox.list.selectedItems[0] : "");
 					var renderer = (id && id !== -1) ? this.combobox.list.getRendererByItemId(id) :
-						this.combobox.list.getRenderers()[0];
+						this.combobox.list.getItemRenderers()[0];
 					this.combobox.list.navigateTo(renderer);
 				}
 			}

--- a/Combobox/ComboPopup.js
+++ b/Combobox/ComboPopup.js
@@ -67,7 +67,7 @@ define([
 		 * @protected
 		 */
 		okHandler: function () {
-			this.combobox._validateMultiple(this.combobox.inputNode);
+			// NOTE: no need to validate since it's handled by the `selection-change` listener
 			this.combobox.closeDropDown();
 		},
 
@@ -76,7 +76,11 @@ define([
 		 * @protected
 		 */
 		cancelHandler: function () {
+			// INFO: resetting any selected items.
+			this.combobox.list.selectedItems = [];
 			this.combobox.closeDropDown();
+			// cont: then ask to validate, so widget's value and inputNode get updated as well.
+			this.combobox._validateMultiple(true);
 		},
 
 		/**

--- a/Combobox/Combobox.html
+++ b/Combobox/Combobox.html
@@ -5,10 +5,11 @@
 		autocomplete="off" autocorrect="off" autocapitalize="none"
 		aria-autocomplete="list"
 		type="text"
-		readonly="{{this._inputReadOnly ? 'readonly' : ''}}">
+		readonly="{{this._inputReadOnly ? 'readonly' : ''}}"
+		placeholder="{{searchPlaceHolder}}">
 	<input class="d-hidden"
 		attach-point="valueNode"
-		readonly name="{{name}}" value="{{value}}">
+		readonly name="{{name}}">
 	<span class="d-combobox-arrow" d-shown="{{hasDownArrow}}"
 		attach-point="buttonNode" aria-hidden="true"></span>
 </template>

--- a/Combobox/Combobox.html
+++ b/Combobox/Combobox.html
@@ -6,7 +6,7 @@
 		aria-autocomplete="list"
 		aria-expanded="{{opened}}"
 		type="text"
-		readonly="{{this._inputReadOnly ? 'readonly' : ''}}"
+		value="{{displayedValue}}"
 		placeholder="{{searchPlaceHolder}}">
 	<input class="d-hidden"
 		attach-point="valueNode"

--- a/Combobox/Combobox.html
+++ b/Combobox/Combobox.html
@@ -4,6 +4,7 @@
 		attach-point="inputNode,focusNode"
 		autocomplete="off" autocorrect="off" autocapitalize="none"
 		aria-autocomplete="list"
+		aria-expanded="{{opened}}"
 		type="text"
 		readonly="{{this._inputReadOnly ? 'readonly' : ''}}"
 		placeholder="{{searchPlaceHolder}}">

--- a/samples/Combobox.html
+++ b/samples/Combobox.html
@@ -170,7 +170,7 @@
 
 	<p>
 	<label for="comboTeams3-input">Your favorite team (single choice):</label><br/>
-	<span>[options: hasDownArrow=false, filterDelay=750ms, minFilterChars=0]</span>
+	<span>[options: hasDownArrow=true, filterDelay=750ms, minFilterChars=0]</span>
 	</p>
 	<d-combobox selectionMode="single" autoFilter="true" id="comboTeams3" hasDownArrow="true" filterDelay="750" minFilterChars="0">
 		<d-list righttextAttr="world-cup-victories" categoryAttr="region" showNoItems="true">
@@ -219,7 +219,7 @@
 	</d-combobox>
 
 	<p>
-	<label for="comboPlayersWithValuesDecl-input">Your favorite players (multiple choice - declaratively ):</label>
+	<label for="comboPlayersWithValuesDecl-input">Your favorite players (multiple choice - declaratively):</label>
 	<br/>Pre-set values = Hagi, Buffon
 	</p>
 	<d-combobox selectionMode="multiple" id="comboPlayersWithValuesDecl" value="Hagi,Buffon">

--- a/samples/Combobox.html
+++ b/samples/Combobox.html
@@ -13,13 +13,15 @@
 
 	<script type="text/javascript">
 		require.config({
-			baseUrl: "../.."
+			baseUrl: "../..",
+			waitSeconds: 60 // for debugging...
 		});
 	</script>
 
 	<script type="text/javascript">
 		require([
 			"requirejs-dplugins/jquery!event",
+			"dstore/Memory",
 			"deliteful/list/List",
 			"deliteful/tests/functional/SlowStore",
 			"deliteful/Combobox",
@@ -28,7 +30,7 @@
 			"deliteful/Checkbox",
 			"delite/theme!delite/themes/{{theme}}/global.css",	// page level CSS
 			"requirejs-domready/domReady!"
-		], function ($, List, SlowStore, Combobox) {
+		], function ($, Memory, List, SlowStore, Combobox) {
 
 			startsWith.on("change", function () {
 				comboTeams.filterMode = "startsWith";
@@ -94,6 +96,17 @@
 			};
 			container.appendChild(comboTeamsAutoComplete);
 
+			var comboEmptyStore = new Combobox({
+				id: "comboEmptyStore",
+				selectionMode: "single",
+				autoFilter: true,
+				hasDownArrow: true,
+				list: new List({showNoItems: true}),
+				source: new Memory()
+			});
+
+			document.getElementById("comboEmptyStoreContainer").appendChild(comboEmptyStore);
+
 			document.body.style.display = "";
 		});
 	</script>
@@ -111,7 +124,7 @@
 	<br/><br/>
 	<p>
 		<label for="comboTeams-input">Your favorite team (single choice):</label><br/>
-		<span>[options: default; displayedValue:"Italy" (value: Italy)]</span>
+		<span>[options: default; value: Italy]</span>
 	</p>
 	<d-combobox selectionMode="single" autoFilter="true" id="comboTeams" value="Italy">
 		<d-list righttextAttr="world-cup-victories" categoryAttr="region" showNoItems="true">
@@ -233,6 +246,11 @@
 	</d-combobox>
 
 	<p>
+	<label for="comboEmptyStoreContainer-input">Combobox with an empty store</label>
+	<br/>
+	<div id="comboEmptyStoreContainer"></div>
+
+	<p>
 	<button is="d-button" onclick="showResults()">Done</button>
 	</p>
 	<br/><br/>
@@ -242,6 +260,7 @@
 	<span>[hasDropDown:false, source: SlowStore, filterDelay:500ms]</span>
 	</p>
 	<div id="comboTeamsAutoCompleteContainer"></div>
+
 	<br/>
 </body>
 </html>

--- a/tests/functional/ComboPopup.html
+++ b/tests/functional/ComboPopup.html
@@ -16,6 +16,7 @@
 	<script type="text/javascript">
 		// global variables used by the automatic functional tests test:
 		var ready = false; // set to true when the test page is ready
+		var storeTestingInfo;
 
 		require.config({
 			config: {
@@ -37,7 +38,7 @@
 			register.deliver();
 
 			// Store information for use in the automatic functional test
-			var storeTestingInfo = function (combo) {
+			storeTestingInfo = function (combo) {
 				if (!combo.init) {
 					combo._inputEventCounter = 0;
 					combo._changeEventCounter = 0;
@@ -67,16 +68,19 @@
 			};
 
 			// single selection mode, autoFilter=true
-			combo = document.getElementById("combo1");
 			storeTestingInfo(document.getElementById("combo1"));
 
 			// single selection mode, autoFilter=true
-			combo = document.getElementById("combo2");
 			storeTestingInfo(document.getElementById("combo2"));
 
 			// multiple selection mode
-			combo = document.getElementById("combo3");
 			storeTestingInfo(document.getElementById("combo3"));
+
+			// auto complete mode, min filter char = 3
+			storeTestingInfo(document.getElementById("combo4"));
+
+			// auto complete mode, min filter char = 0
+			storeTestingInfo(document.getElementById("combo5"));
 
 			// Used by the automatic functional test, for comboboxes in both
 			// single and multiple selection modes.
@@ -95,6 +99,7 @@
 						combo.inputNode.getAttribute("aria-activedescendant"));
 				return {
 					inputNodeValue: combo.inputNode.value,
+					popupInputNodeValue: combo.opened ? combo.dropDown.inputNode.value : "",
 					widgetValue: combo.value,
 					valueNodeValue: combo.valueNode.value,
 					opened: combo.opened,
@@ -142,7 +147,7 @@
 	</h1>
 
 	<label for="combo1-input">
-		Simple Combobox popup
+		id = combo1 - Simple Combobox popup
 	</label>
 	<d-combobox selectionMode="single" autoFilter="false" id="combo1" name="combo1" value="France">
 		<d-list righttextAttr="sales" categoryAttr="region">
@@ -187,7 +192,7 @@
 	</d-combobox>
 
 	<label for="combo2-input">
-		Combobox popup with &lt;input&gt; (autoFilter=true)
+		id = combo2 - Combobox popup with &lt;input&gt; (autoFilter=true)
 	</label>
 	<d-combobox selectionMode="single" autoFilter="true" id="combo2" name="combo2" value="France">
 		<d-list righttextAttr="sales" categoryAttr="region" showNoItems="true">
@@ -232,7 +237,7 @@
 	</d-combobox>
 
 	<label for="combo3-input">
-		Combobox with OK/cancel button (multiselect)
+		id = combo3 - Combobox with OK/cancel button (multiselect)
 	</label>
 	<d-combobox selectionMode="multiple" autoFilter="false" id="combo3" name="combo3">
 		<d-list righttextAttr="sales" categoryAttr="region">
@@ -277,7 +282,7 @@
 	</d-combobox>
 
 	<label for="combo4-input">
-		Combobox popup with &lt;input&gt; autoFilter=true, hasDownArrow=false, minFilterChars=3, "AutoComplete" mode
+		id = combo4 - Combobox popup with &lt;input&gt; autoFilter=true, hasDownArrow=false, minFilterChars=3, "AutoComplete" mode
 	</label>
 	<d-combobox selectionMode="single" autoFilter="true" hasDownArrow="false" id="combo4" name="combo4" minFilterChars="3">
 		<d-list righttextAttr="sales" categoryAttr="region" showNoItems="true">
@@ -322,7 +327,7 @@
 	</d-combobox>
 
 	<label for="combo5-input">
-		Combobox popup with &lt;input&gt; (autoFilter=true), hasDownArrow=false, minFilterChars=0, "AutoComplete" mode
+		id = combo5 - Combobox popup with &lt;input&gt; (autoFilter=true), hasDownArrow=false, minFilterChars=0, "AutoComplete" mode
 	</label>
 	<d-combobox selectionMode="single" autoFilter="true" hasDownArrow="false" id="combo5" name="combo5" minFilterChars="0">
 		<d-list righttextAttr="sales" categoryAttr="region" showNoItems="true">

--- a/tests/functional/ComboPopup.js
+++ b/tests/functional/ComboPopup.js
@@ -683,7 +683,7 @@ define([
 			.end()
 			.findByCssSelector(".d-linear-layout .d-combobox-list[d-shown='false']") // list not visible
 			.then(function (list) {
-				assert.isNotNull(list, "list should be invisible at this stage.")
+				assert.isNotNull(list, "list should be invisible at this stage.");
 			})
 			.end()
 			.findByCssSelector(".d-linear-layout .d-combobox-input[d-hidden='false']") // inputNode
@@ -711,7 +711,7 @@ define([
 			.end()
 			.findByCssSelector(".d-linear-layout .d-combobox-list[d-shown='false']") // list not visible
 			.then(function (list) {
-				assert.isNotNull(list, "list should be invisible at this stage.")
+				assert.isNotNull(list, "list should be invisible at this stage.");
 			})
 			.end()
 			.pressKeys("p")
@@ -738,7 +738,7 @@ define([
 			.end()
 			.findByCssSelector(".d-linear-layout .d-combobox-list[d-shown='true']") // list visible
 			.then(function (list) {
-				assert.isNotNull(list, "list should be visible at this stage.")
+				assert.isNotNull(list, "list should be visible at this stage.");
 			})
 			.end()
 			.findByCssSelector(".d-linear-layout .d-combobox-input[d-hidden='false']") // inputNode
@@ -766,7 +766,7 @@ define([
 			.end()
 			.findByCssSelector(".d-linear-layout .d-combobox-list[d-shown='false']") // list not visible
 			.then(function (list) {
-				assert.isNotNull(list, "list should be visible at this stage.")
+				assert.isNotNull(list, "list should be visible at this stage.");
 			})
 			.end()
 			.findByCssSelector(".d-linear-layout .d-combobox-input[d-hidden='false']") // inputNode
@@ -794,10 +794,11 @@ define([
 			})
 			.isDisplayed() // check if popup is still visible.
 			.then(function (isVisible) {
-				assert.isTrue(isVisible, "popup must be visible at this stage.")
+				assert.isTrue(isVisible, "popup must be visible at this stage.");
 			})
-			.end()
+			.end();
 	};
+
 	var checkAutoCompleteFilteringWithZeroFilterChars = function (remote, comboId) {
 		var executeExpr = "return getComboState(\"" + comboId + "\");";
 		return loadFile(remote, "./ComboPopup.html")
@@ -869,7 +870,7 @@ define([
 			.end()
 			.findByCssSelector(".d-linear-layout .d-combobox-list[d-shown='true']") // list visible
 			.then(function (list) {
-				assert.isNotNull(list, "list should be invisible at this stage.")
+				assert.isNotNull(list, "list should be invisible at this stage.");
 			})
 			.end()
 			.findByCssSelector(".d-linear-layout .d-combobox-input[d-hidden='false']") // inputNode
@@ -897,7 +898,7 @@ define([
 			.end()
 			.findByCssSelector(".d-linear-layout .d-combobox-list[d-shown='true']") // list visible
 			.then(function (list) {
-				assert.isNotNull(list, "list should be invisible at this stage.")
+				assert.isNotNull(list, "list should be visible at this stage.");
 			})
 			.end()
 			.findByCssSelector(".d-linear-layout .d-combobox-input[d-hidden='false']") // inputNode
@@ -927,7 +928,7 @@ define([
 			.end()
 			.findByCssSelector(".d-linear-layout .d-combobox-list[d-shown='false']") // list not visible
 			.then(function (list) {
-				assert.isNotNull(list, "list should be visible at this stage.")
+				assert.isNotNull(list, "list should be not visible at this stage.");
 			})
 			.end()
 			.findByCssSelector(".d-linear-layout .d-combobox-input[d-hidden='false']") // inputNode
@@ -956,7 +957,7 @@ define([
 			.end()
 			.findByCssSelector(".d-linear-layout .d-combobox-list[d-shown='true']") // list visible
 			.then(function (list) {
-				assert.isNotNull(list, "list should be visible at this stage.")
+				assert.isNotNull(list, "list should be visible at this stage.");
 			})
 			.end()
 			.findByCssSelector(".d-linear-layout .d-combobox-input[d-hidden='false']") // inputNode
@@ -985,14 +986,14 @@ define([
 			.end()
 			.findByCssSelector(".d-linear-layout .d-combobox-list[d-shown='false']") // list not visible
 			.then(function (list) {
-				assert.isNotNull(list, "list should be visible at this stage.")
+				assert.isNotNull(list, "list should be not visible at this stage.");
 			})
 			.end()
 			.isDisplayed() // check if popup is still visible.
 			.then(function (isVisible) {
-				assert.isTrue(isVisible, "popup must be visible at this stage.")
+				assert.isTrue(isVisible, "popup must be visible at this stage.");
 			})
-			.end()
+			.end();
 	};
 
 	registerSuite({
@@ -1088,7 +1089,7 @@ define([
 			return checkSingleSelection(remote, "combo2", true);
 		},
 
-		"multi selection selection (combo3)": function () {
+		"multi selection (combo3)": function () {
 			var remote = this.remote;
 
 			if (remote.environmentType.browserName === "internet explorer") {
@@ -1103,7 +1104,7 @@ define([
 			return checkMultiSelection(remote, "combo3");
 		},
 
-		"multi selection selection (combo3)": function () {
+		"multi selection cancel button (combo3)": function () {
 			var remote = this.remote;
 
 			if (remote.environmentType.browserName === "internet explorer") {
@@ -1183,7 +1184,7 @@ define([
 		},
 
 		"autocomplete filtering - minFilterChars = 0 (combo5)": function () {
-						var remote = this.remote;
+			var remote = this.remote;
 
 			if (remote.environmentType.browserName === "internet explorer") {
 				// https://github.com/theintern/leadfoot/issues/17

--- a/tests/functional/ComboPopup.js
+++ b/tests/functional/ComboPopup.js
@@ -117,6 +117,18 @@ define([
 					}, "after click on root node");
 			})
 			.findByCssSelector(".d-combo-popup .d-linear-layout .d-combobox-input[d-hidden='false']")
+			.pressKeys(keys.BACKSPACE) // Delete the 6 chars of "France"
+			.sleep(100)
+			.pressKeys(keys.BACKSPACE)
+			.sleep(100)
+			.pressKeys(keys.BACKSPACE)
+			.sleep(100)
+			.pressKeys(keys.BACKSPACE)
+			.sleep(100)
+			.pressKeys(keys.BACKSPACE)
+			.sleep(100)
+			.pressKeys(keys.BACKSPACE)
+			.sleep(100)
 			.type("j")
 			.type("a")
 			.type("p")
@@ -132,7 +144,7 @@ define([
 						opened: true,
 						selectedItemsCount: 0,
 						itemRenderersCount: 30,
-						inputEventCounter: 3, // typed "jap"
+						inputEventCounter: 9, // removed "france" and typed "jap"
 						changeEventCounter: 0,
 						widgetValueAtLatestInputEvent: "jap",
 						valueNodeValueAtLatestInputEvent: "jap",
@@ -585,50 +597,50 @@ define([
 	registerSuite({
 		name: "ComboPopup - functional",
 
-		"list in popup (combo1)": function () {
-			var remote = this.remote;
+		// "list in popup (combo1)": function () {
+		// 	var remote = this.remote;
 
-			if (remote.environmentType.browserName === "internet explorer") {
-				// https://github.com/theintern/leadfoot/issues/17
-				return this.skip("click() doesn't generate mousedown/mouseup, so popup won't open");
-			}
-			if (remote.environmentType.platformName === "iOS") {
-				// https://github.com/theintern/leadfoot/issues/61
-				return this.skip("click() doesn't generate touchstart/touchend, so popup won't open");
-			}
+		// 	if (remote.environmentType.browserName === "internet explorer") {
+		// 		// https://github.com/theintern/leadfoot/issues/17
+		// 		return this.skip("click() doesn't generate mousedown/mouseup, so popup won't open");
+		// 	}
+		// 	if (remote.environmentType.platformName === "iOS") {
+		// 		// https://github.com/theintern/leadfoot/issues/61
+		// 		return this.skip("click() doesn't generate touchstart/touchend, so popup won't open");
+		// 	}
 
-			return checkListInPopup(remote, "combo1", false, false);
-		},
+		// 	return checkListInPopup(remote, "combo1", false, false);
+		// },
 
-		"list in popup (combo2)": function () {
-			var remote = this.remote;
+		// "list in popup (combo2)": function () {
+		// 	var remote = this.remote;
 
-			if (remote.environmentType.browserName === "internet explorer") {
-				// https://github.com/theintern/leadfoot/issues/17
-				return this.skip("click() doesn't generate mousedown/mouseup, so popup won't open");
-			}
-			if (remote.environmentType.platformName === "iOS") {
-				// https://github.com/theintern/leadfoot/issues/61
-				return this.skip("click() doesn't generate touchstart/touchend, so popup won't open");
-			}
+		// 	if (remote.environmentType.browserName === "internet explorer") {
+		// 		// https://github.com/theintern/leadfoot/issues/17
+		// 		return this.skip("click() doesn't generate mousedown/mouseup, so popup won't open");
+		// 	}
+		// 	if (remote.environmentType.platformName === "iOS") {
+		// 		// https://github.com/theintern/leadfoot/issues/61
+		// 		return this.skip("click() doesn't generate touchstart/touchend, so popup won't open");
+		// 	}
 
-			return checkListInPopup(remote, "combo2", true, false);
-		},
+		// 	return checkListInPopup(remote, "combo2", true, false);
+		// },
 
-		"list in popup (combo3)": function () {
-			var remote = this.remote;
+		// "list in popup (combo3)": function () {
+		// 	var remote = this.remote;
 
-			if (remote.environmentType.browserName === "internet explorer") {
-				// https://github.com/theintern/leadfoot/issues/17
-				return this.skip("click() doesn't generate mousedown/mouseup, so popup won't open");
-			}
-			if (remote.environmentType.platformName === "iOS") {
-				// https://github.com/theintern/leadfoot/issues/61
-				return this.skip("click() doesn't generate touchstart/touchend, so popup won't open");
-			}
+		// 	if (remote.environmentType.browserName === "internet explorer") {
+		// 		// https://github.com/theintern/leadfoot/issues/17
+		// 		return this.skip("click() doesn't generate mousedown/mouseup, so popup won't open");
+		// 	}
+		// 	if (remote.environmentType.platformName === "iOS") {
+		// 		// https://github.com/theintern/leadfoot/issues/61
+		// 		return this.skip("click() doesn't generate touchstart/touchend, so popup won't open");
+		// 	}
 
-			return checkListInPopup(remote, "combo3", false, true);
-		},
+		// 	return checkListInPopup(remote, "combo3", false, true);
+		// },
 
 		"filtering (combo2)": function () {
 			var remote = this.remote;

--- a/tests/functional/Combobox-decl.html
+++ b/tests/functional/Combobox-decl.html
@@ -144,6 +144,12 @@
 				};
 			};
 
+			getNavigatedDescendant = function (comboId) {
+				var combo = document.getElementById(comboId);
+				return combo.list && combo.list.navigatedDescendant
+					&& combo.list.navigatedDescendant.textContent.trim();
+			};
+
 			isAligned = function (comboId, pos) {
 				var combo = document.getElementById(comboId);
 				var popup = document.getElementById(comboId +  "_dropdown_wrapper");

--- a/tests/functional/Combobox-decl.html
+++ b/tests/functional/Combobox-decl.html
@@ -17,6 +17,7 @@
 		// global variables used by the automatic functional tests test:
 		var ready = false; // set to true when the test page is ready
 		var getComboState;
+		var storeTestingInfo;
 
 		require([
 			"delite/register",
@@ -61,7 +62,7 @@
 			combo.deliver();
 
 			// Store information for use in the automatic functional test
-			var storeTestingInfo = function (combo) {
+			storeTestingInfo = function (combo) {
 				if (!combo.init) {
 					combo._inputEventCounter = 0;
 					combo._changeEventCounter = 0;
@@ -91,22 +92,22 @@
 			};
 
 			// single selection mode, autoFilter=true
-			combo = document.getElementById("combo1");
 			storeTestingInfo(document.getElementById("combo1"));
 
 			// single selection mode, autoFilter=true
-			combo = document.getElementById("combo2");
 			storeTestingInfo(document.getElementById("combo2"));
 
 			// multiple selection mode
-			combo = document.getElementById("combo3");
 			storeTestingInfo(document.getElementById("combo3"));
 
-			combo = document.getElementById("combo-minfilterchars0");
+			// single selection mode, autofilter=true, minFilterChars = 0
 			storeTestingInfo(document.getElementById("combo-minfilterchars0"));
 
-			combo = document.getElementById("combo-minfilterchars3");
+			// single selection mode, autofilter=true, minFilterChars = 3
 			storeTestingInfo(document.getElementById("combo-minfilterchars3"));
+
+			// single selection mode, auto-complete mode (hasDownArrow = false)
+			storeTestingInfo(document.getElementById("combo-autocomplete"));
 
 			// Used by the automatic functional test, for comboboxes in both
 			// single and multiple selection modes.
@@ -712,14 +713,23 @@
 		</d-list>
 	</d-combobox>
 
-	<label for="combo-slowstore">
+	<label for="combo-slowstore-input">
 		id: "combo-slowstore", selectionMode: "single", autoFilter: true,
 	</label>
 	<d-combobox selectionMode="single" autoFilter="true"
 		id="combo-slowstore" name="combo-slowstore" filterDelay="100">
 	</d-combobox>
 
-	<label for="combo-minfilterchars0">
+	<label for="combo-empty-store-input">
+		id: "combo-empty-store", selectionMode: "single", autoFilter: true, hasDownArrow: false
+	</label>
+	<d-combobox selectionMode="single" hasDownArrow="true" autoFilter="true"
+		id="combo-empty-store" name="combo-empty-store">
+		<d-list righttextAttr="sales" categoryAttr="region" showNoItems="true">
+		</d-list>
+	</d-combobox>
+
+	<label for="combo-minfilterchars0-input">
 		id: "combo-minfilterchars0", selectionMode: "single", autoFilter: true, minFilterChars: 0
 	</label>
 	<d-combobox selectionMode="single" autoFilter="true" minFilterChars="0"
@@ -765,12 +775,57 @@
 		</d-list>
 	</d-combobox>
 
-	<label for="combo-minfilterchars3">
+	<label for="combo-minfilterchars3-input">
 		id: "combo-minfilterchars3", selectionMode: "single", autoFilter: true, minFilterChars: 3
 	</label>
 	<d-combobox selectionMode="single" autoFilter="true" minFilterChars="3"
 		id="combo-minfilterchars3" name="combo-minfilterchars3" value="France">
 		<d-list righttextAttr="sales" categoryAttr="region">
+			{ "label": "France", "sales": 500, "profit": 50, "region": "EU" },
+			{ "label": "Germany", "sales": 450, "profit": 48, "region": "EU" },
+			{ "label": "UK", "sales": 700, "profit": 60, "region": "EU" },
+			{ "label": "USA", "sales": 2000, "profit": 250, "region": "America" },
+			{ "label": "Canada", "sales": 600, "profit": 30, "region": "America" },
+			{ "label": "Brazil", "sales": 450, "profit": 30, "region": "America" },
+			{ "label": "China", "sales": 500, "profit": 40, "region": "Asia" },
+			{ "label": "Japan", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan2", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan3", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan4", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan5", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan6", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan7", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan8", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan9", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan10", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan11", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan12", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan13", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan14", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan15", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan16", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan17", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan18", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan19", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan20", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan21", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan22", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan23", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan24", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan25", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan26", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan27", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan28", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan29", "sales": 900, "profit": 100, "region": "Asia" },
+			{ "label": "Japan30", "sales": 900, "profit": 100, "region": "Asia" }
+		</d-list>
+	</d-combobox>
+
+	<label for="combo-autocomplete-input">
+		id: "combo-autocomplete", hasDownArrow: false
+	</label>
+	<d-combobox hasDownArrow="false" id="combo-autocomplete" name="combo-autocomplete">
+		<d-list righttextAttr="sales" categoryAttr="region" showNoItems="true">
 			{ "label": "France", "sales": 500, "profit": 50, "region": "EU" },
 			{ "label": "Germany", "sales": 450, "profit": 48, "region": "EU" },
 			{ "label": "UK", "sales": 700, "profit": 60, "region": "EU" },

--- a/tests/functional/Combobox-prog.html
+++ b/tests/functional/Combobox-prog.html
@@ -38,7 +38,7 @@
 					{ label: "Japan", sales: 900, profit: 100, region: "Asia" }
 			]});
 			var dataSourceWithValue = new Memory(
-				{idProperty: "label",
+				{idProperty: "myValue",
 				data: [
 					{ label: "France", myValue: "FR", sales: 500, profit: 50, region: "EU" },
 					{ label: "Germany", myValue: "DE", sales: 450, profit: 48, region: "EU" },

--- a/tests/functional/Combobox.js
+++ b/tests/functional/Combobox.js
@@ -857,6 +857,151 @@ define([
 			.execute(comboId + ".closeDropDown();");
 	};
 
+	var checkNavigatedDescendantNoSelection = function (remote, comboId) {
+		var executeExpr = "return getNavigatedDescendant(\"" + comboId + "\");";
+		return loadFile(remote, "./Combobox-decl.html")
+			.execute(comboId + ".focus();")
+			.pressKeys(keys.ARROW_DOWN)
+			.sleep(500)
+			.execute(executeExpr)
+			.then(function (navigatedDescendant) {
+				assert.isNull(navigatedDescendant, "navigatedDescendant should be still null.");
+			})
+			.pressKeys(keys.ARROW_DOWN)
+			.sleep(500)
+			.execute(executeExpr)
+			.then(function (navigatedDescendant) {
+				assert(/^France/.test(navigatedDescendant),
+					"navigatedDescendant after first ARROW_DOWN: " + navigatedDescendant);
+			})
+			.pressKeys(keys.ARROW_DOWN)
+			.pressKeys(keys.ARROW_DOWN)
+			.pressKeys(keys.ARROW_DOWN)
+			.pressKeys(keys.ARROW_DOWN) // focus on Cananda
+			.sleep(500)
+			.execute(executeExpr)
+			.then(function (navigatedDescendant) {
+				assert(/^Canada/.test(navigatedDescendant),
+					"navigatedDescendant after forth ARROW_DOWN: " + navigatedDescendant);
+			})
+			.pressKeys(keys.ESCAPE)
+			.sleep(500) // wait for async closing
+			.execute(executeExpr)
+			.then(function (navigatedDescendant) {
+				// note: even if the popup it's closed, list should maintain its navigatedDescendant set.
+				assert(/^Canada/.test(navigatedDescendant),
+					"navigatedDescendant after closing the popup: " + navigatedDescendant);
+			})
+			.pressKeys(keys.ARROW_DOWN)
+			.sleep(500) // wait for async opening
+			.execute(executeExpr)
+			.then(function (navigatedDescendant) {
+				assert(/^Canada/.test(navigatedDescendant),
+					"navigatedDescendant after opening the popup: " + navigatedDescendant);
+			})
+			.pressKeys(keys.ARROW_DOWN)
+			.pressKeys(keys.ARROW_DOWN) // focus on Cananda
+			.sleep(500)
+			.execute(executeExpr)
+			.then(function (navigatedDescendant) {
+				assert(/^China/.test(navigatedDescendant),
+					"navigatedDescendant after two ARROW_DOWN: " + navigatedDescendant);
+			});
+	};
+
+	var checkNavigatedDescendantWithSelection = function (remote, comboId) {
+		var executeExpr = "return getNavigatedDescendant(\"" + comboId + "\");";
+		return loadFile(remote, "./Combobox-decl.html")
+			.execute(comboId + ".focus();")
+			.pressKeys(keys.ARROW_DOWN)
+			.sleep(500)
+			.execute(executeExpr)
+			.then(function (navigatedDescendant) {
+				assert.isNull(navigatedDescendant, "navigatedDescendant should be still null.");
+			})
+			.pressKeys(keys.ARROW_DOWN)
+			.sleep(500)
+			.execute(executeExpr)
+			.then(function (navigatedDescendant) {
+				assert(/^France/.test(navigatedDescendant),
+					"navigatedDescendant after first ARROW_DOWN: " + navigatedDescendant);
+			})
+			.pressKeys(keys.ARROW_DOWN)
+			.pressKeys(keys.ARROW_DOWN)
+			.findById(comboId + "_item2")
+			.click() // UK selected
+			.end()
+			.sleep(500)
+			.execute(executeExpr)
+			.then(function (navigatedDescendant) {
+				assert(/^UK/.test(navigatedDescendant),
+					"navigatedDescendant after two ARROW_DOWN: " + navigatedDescendant);
+			})
+			.pressKeys(keys.ARROW_DOWN)
+			.pressKeys(keys.ARROW_DOWN)
+			.sleep(500)
+			.execute(executeExpr)
+			.then(function (navigatedDescendant) {
+				assert(/^Canada/.test(navigatedDescendant),
+					"navigatedDescendant after other two ARROW_DOWN: " + navigatedDescendant);
+			})
+			.pressKeys(keys.ESCAPE)
+			.sleep(500) // wait for async closing
+			.execute(executeExpr)
+			.then(function (navigatedDescendant) {
+				// note: even if the popup it's closed, list should maintain its navigatedDescendant set.
+				assert(/^Canada/.test(navigatedDescendant),
+					"navigatedDescendant after closing the popup: " + navigatedDescendant);
+			})
+			.pressKeys(keys.ARROW_DOWN)
+			.sleep(500) // wait for async opening
+			.execute(executeExpr)
+			.then(function (navigatedDescendant) {
+				// note: on opening, the widget does focus on the navigated descendant
+				assert(/^Canada/.test(navigatedDescendant),
+					"navigatedDescendant after opening the popup: " + navigatedDescendant);
+			})
+			.pressKeys(keys.ARROW_DOWN)
+			.pressKeys(keys.ARROW_DOWN) // focus on Cananda
+			.sleep(500)
+			.execute(executeExpr)
+			.then(function (navigatedDescendant) {
+				assert(/^China/.test(navigatedDescendant),
+					"navigatedDescendant after two ARROW_DOWN: " + navigatedDescendant);
+			})
+	};
+
+	var checkNavigatedDescendantWithPreSelection = function (remote, comboId) {
+		var executeExpr = "return getNavigatedDescendant(\"" + comboId + "\");";
+		return loadFile(remote, "./Combobox-decl.html")
+			.execute("document.getElementById(\"" + comboId + "\").focus();")
+			.pressKeys(keys.ARROW_DOWN)
+			.sleep(500)
+			.execute(executeExpr)
+			.then(function (navigatedDescendant) {
+				// note: Germany is preselected.
+				assert(/^Germany/.test(navigatedDescendant),
+					"navigatedDescendant after first ARROW_DOWN: " + navigatedDescendant);
+			})
+			.pressKeys(keys.ARROW_DOWN)
+			.sleep(500)
+			.execute(executeExpr)
+			.then(function (navigatedDescendant) {
+				assert(/^UK/.test(navigatedDescendant),
+					"navigatedDescendant after second ARROW_DOWN: " + navigatedDescendant);
+			})
+			.pressKeys(keys.ESCAPE)
+			.sleep(500) // wait for async closing
+			.pressKeys(keys.ARROW_DOWN)
+			.sleep(500) // wait for async opening
+			.execute(executeExpr)
+			.then(function (navigatedDescendant) {
+				// note: on opening, the widget does focus on the navigated descendant
+				assert(/^UK/.test(navigatedDescendant),
+					"navigatedDescendant after opening the popup: " + navigatedDescendant);
+			})
+	};
+
 	var checkPopupPosition = function (remote, comboId, position) {
 		return loadFile(remote, "./Combobox-decl.html")
 			.execute("return moveToBottom(\"" + comboId + "\");")
@@ -1189,6 +1334,30 @@ define([
 				return this.skip("no keyboard support");
 			}
 			return checkKeyboardNavigationAutoscroll(remote, "combo3");
+		},
+
+		"check navigatedDescendant (no selection)": function () {
+			var remote = this.remote;
+			if (remote.environmentType.brokenSendKeys || !remote.environmentType.nativeEvents) {
+				return this.skip("no keyboard support");
+			}
+			return checkNavigatedDescendantNoSelection(remote, "combo3");
+		},
+
+		"check navigatedDescendant (with selection)": function () {
+			var remote = this.remote;
+			if (remote.environmentType.brokenSendKeys || !remote.environmentType.nativeEvents) {
+				return this.skip("no keyboard support");
+			}
+			return checkNavigatedDescendantWithSelection(remote, "combo3");
+		},
+
+		"check navigatedDescendant (with pre-selection)": function () {
+			var remote = this.remote;
+			if (remote.environmentType.brokenSendKeys || !remote.environmentType.nativeEvents) {
+				return this.skip("no keyboard support");
+			}
+			return checkNavigatedDescendantWithPreSelection(remote, "combo2-custom-sel-multiple");
 		},
 
 		"mouse navigation selectionMode=single, autoFilter=false": function () {

--- a/tests/functional/Combobox.js
+++ b/tests/functional/Combobox.js
@@ -968,7 +968,7 @@ define([
 			.then(function (navigatedDescendant) {
 				assert(/^China/.test(navigatedDescendant),
 					"navigatedDescendant after two ARROW_DOWN: " + navigatedDescendant);
-			})
+			});
 	};
 
 	var checkNavigatedDescendantWithPreSelection = function (remote, comboId) {
@@ -999,7 +999,7 @@ define([
 				// note: on opening, the widget does focus on the navigated descendant
 				assert(/^UK/.test(navigatedDescendant),
 					"navigatedDescendant after opening the popup: " + navigatedDescendant);
-			})
+			});
 	};
 
 	var checkPopupPosition = function (remote, comboId, position) {

--- a/tests/unit/Combobox.js
+++ b/tests/unit/Combobox.js
@@ -612,7 +612,7 @@ define([
 			return d;
 		},
 
-		"inputNode: aria-expanded attribute on open/close popup": function () {
+		"widget.inputNode aria-expanded attribute on open/close popup": function () {
 			var combo = new Combobox({labelAttr: "name"});
 			var dataSource = new Memory(
 				{idProperty: "name",
@@ -632,7 +632,6 @@ define([
 			combo.deliver();
 
 			var d = this.async(2000);
-			console.log(combo.inputNode);
 			assert.strictEqual(combo.inputNode.getAttribute("aria-expanded"), "false",
 				"aria-expanded - popup is closed: " + combo.id);
 
@@ -644,6 +643,70 @@ define([
 					assert.strictEqual(combo.inputNode.getAttribute("aria-expanded"), "false",
 					"aria-expanded - popup is closed: " + combo.id);
 				}), 200);
+			}));
+
+			return d;
+		},
+
+		"widget.inputNode readOnly attribute": function () {
+			var combo = new Combobox({labelAttr: "name", autoFilter: true});
+			var dataSource = new Memory(
+				{idProperty: "name",
+					data: [
+					{ name: "Japan", sales: 900, profit: 100, region: "Asia" },
+					{ name: "France", sales: 500, profit: 50, region: "EU" },
+					{ name: "Canada", sales: 600, profit: 30, region: "America" },
+					{ name: "Brazil", sales: 450, profit: 30, region: "America" },
+					{ name: "China", sales: 500, profit: 40, region: "Asia" }
+				]});
+			container.appendChild(combo);
+			combo.attachedCallback();
+			combo.deliver();
+
+			assert.isTrue(combo.inputNode.readOnly,
+				"readOnly should be true, because source is empty.");
+
+			combo.source = dataSource;
+			combo.deliver();
+			assert.isFalse(combo.inputNode.readOnly,
+				"readOnly should be false, because source is not empty.");
+		},
+
+		"widget.inputNode read0nly attribute on list source change.": function () {
+			var combo = new Combobox({labelAttr: "name", autoFilter: true});
+			var dataSource = new Memory(
+				{idProperty: "name",
+					data: [
+					{ name: "Japan", sales: 900, profit: 100, region: "Asia" },
+					{ name: "France", sales: 500, profit: 50, region: "EU" },
+					{ name: "Canada", sales: 600, profit: 30, region: "America" },
+					{ name: "Brazil", sales: 450, profit: 30, region: "America" },
+					{ name: "China", sales: 500, profit: 40, region: "Asia" }
+				]});
+
+			var dataSourceEmpty = new Memory({idProperty: "name", data: []});
+
+			container.appendChild(combo);
+			combo.source = dataSource;
+			combo.attachedCallback();
+			combo.deliver();
+
+			assert.isFalse(combo.inputNode.readOnly,
+				"readOnly should be true, because source is not empty and autoFilter is true.");
+
+			var d = this.async(2000);
+			var delay = 200;
+			// open the dropdown, so the list gets combo's source attached.
+			combo.openDropDown().then(d.rejectOnError(function () {
+				setTimeout(d.callback(function () {
+					combo.closeDropDown();
+					// attaching an empty source to the list.
+					combo.list.source = dataSourceEmpty;
+					combo.list.deliver();
+					combo.deliver();
+					assert.isTrue(combo.inputNode.readOnly,
+						"readOnly should be true, because source is now empty.");
+				}), delay);
 			}));
 
 			return d;

--- a/tests/unit/Combobox.js
+++ b/tests/unit/Combobox.js
@@ -203,6 +203,7 @@ define([
 		assert.strictEqual(combo.baseClass, outerCSS, "combo.baseClass");
 		assert.strictEqual(combo.filterMode, "startsWith", "combo.filterMode");
 		assert.isTrue(combo.ignoreCase, "combo.ignoreCase");
+		assert.strictEqual(combo.inputNode.placeholder, "Search", combo.inputNode.placeholder);
 	};
 
 	var CommonTestCases = {

--- a/tests/unit/Combobox.js
+++ b/tests/unit/Combobox.js
@@ -612,6 +612,43 @@ define([
 			return d;
 		},
 
+		"inputNode: aria-expanded attribute on open/close popup": function () {
+			var combo = new Combobox({labelAttr: "name"});
+			var dataSource = new Memory(
+				{idProperty: "name",
+					data: [
+					{ name: "Japan", sales: 900, profit: 100, region: "Asia" },
+					{ name: "France", sales: 500, profit: 50, region: "EU" },
+					{ name: "Germany", sales: 450, profit: 48, region: "EU" },
+					{ name: "UK", sales: 700, profit: 60, region: "EU" },
+					{ name: "USA", sales: 2000, profit: 250, region: "America" },
+					{ name: "Canada", sales: 600, profit: 30, region: "America" },
+					{ name: "Brazil", sales: 450, profit: 30, region: "America" },
+					{ name: "China", sales: 500, profit: 40, region: "Asia" }
+				]});
+			combo.source = dataSource;
+			container.appendChild(combo);
+			combo.attachedCallback();
+			combo.deliver();
+
+			var d = this.async(2000);
+			console.log(combo.inputNode);
+			assert.strictEqual(combo.inputNode.getAttribute("aria-expanded"), "false",
+				"aria-expanded - popup is closed: " + combo.id);
+
+			combo.openDropDown().then(d.rejectOnError(function () {
+				assert.strictEqual(combo.inputNode.getAttribute("aria-expanded"), "true",
+				"aria-expanded - popup is open: " + combo.id);
+				combo.closeDropDown();
+				setTimeout(d.callback(function () {
+					assert.strictEqual(combo.inputNode.getAttribute("aria-expanded"), "false",
+					"aria-expanded - popup is closed: " + combo.id);
+				}), 200);
+			}));
+
+			return d;
+		},
+
 		// Test case for #509: initialization of Combobox after List rendering is ready.
 		// "initialization with List rendering after Combobox initialization": function () {
 		// 	var combo = new Combobox(); // single selection mode


### PR DESCRIPTION
This PR:
- Fixes broken placeholder - _Actually I don't remember it was working before the Combobox refactor at _ 785de8437cb0b1d2754678a01c558fc6637ddad8.
- displayedValue prop refers to the value to display at each user interaction. If it's not provided at instantiation time, it will be retrieved from the source, using the value as key. Only valid if `source != null`
- Delay the widget initialization if the list has not been created yet.
- Restore down-arrow key original behaviour, even if the inputNode is empty. This means that if you press down arrow key, the popup will open - (Fixes accessibility issues).
- Fixes #677. _This bug has been introduced by_ 785de8437cb0b1d2754678a01c558fc6637ddad8
- Do not forward selection event to the list if dropdown is not opened.  _This bug has been there before the refactor at_ 785de8437cb0b1d2754678a01c558fc6637ddad8.
**Issue explanation**: In case of Combobox configured in "selectionMode=multiple", "Spacebar" events are sent to the list even though the dropdown is closed, resulting in a weird/ambiguous Combobox's selection behavior.  
![selection](https://cloud.githubusercontent.com/assets/4410485/20759319/8502ac22-b714-11e6-92a2-9fe9f32630c7.gif)

- Fixes broken readOnly property. _This bug has been there before the refactor at_ 785de8437cb0b1d2754678a01c558fc6637ddad8. 
**Issue explanation**: even if the widget is set i.e. in `autoFilter=false` OR `selectionMode=multiple`, at the creation time the widget's `inputNode` does not have the `readonly` attribute set, despite the `this.notifyCurrentValue("_inputReadOnly")` is executed. From my debugging I see that the notification about the `_inputReadOnly` property is delivered only when the user starts to interact with the widgets, i.e. when the user opens the dropdown. However, this is too late. In fact, if the user gets the focus on the widget via tabbing over the page and then he starts typing, the input is still "no-readonly" mode, allowing so the actual typing.
![readonly](https://cloud.githubusercontent.com/assets/4410485/20759999/89933048-b716-11e6-9eee-36ab653858a9.gif)
