### PR TITLE
List#handleSelection uses navigatedDescendant instead of evt.target.

### DIFF
--- a/list/List.js
+++ b/list/List.js
@@ -564,10 +564,10 @@ define([
 		 * @protected
 		 */
 		handleSelection: function (/*Event*/event) {
-			var eventRenderer = this.getEnclosingRenderer(event.target);
-			if (eventRenderer) {
-				if (!this.isCategoryRenderer(eventRenderer)) {
-					this.selectFromEvent(event, eventRenderer.item, eventRenderer, true);
+			var renderer = this.getEnclosingRenderer(this.navigatedDescendant);
+			if (renderer) {
+				if (!this.isCategoryRenderer(renderer)) {
+					this.selectFromEvent(event, renderer.item, renderer, true);
 				}
 				return true;
 			}


### PR DESCRIPTION
With List & PagebleList refactor at 3338825d03ab7b66152fd7bcae9d30d9428c2fff, the concerns expressed with #500 and [#497 comment by @wkeese](https://github.com/ibm-js/deliteful/pull/497#commitcomment-9489009) should not be valid, because `PageableList` does not override `List#handleSelection` anymore. So we can use `list.navigatedDescendant` instead of `evt.target` to find out the render the (de-)selection have to be applied on.

However this brings some List's Selection.js tests to fail.

**This is still a WIP and must not be accepted until further commits.**