### PR TITLE
Fix Combobox's placeholder for inputNode.

### DIFF
--- a/Combobox/Combobox.html
+++ b/Combobox/Combobox.html
@@ -5,7 +5,8 @@
 		autocomplete="off" autocorrect="off" autocapitalize="none"
 		aria-autocomplete="list"
 		type="text"
-		readonly="{{this._inputReadOnly ? 'readonly' : ''}}">
+		readonly="{{this._inputReadOnly ? 'readonly' : ''}}"
+		placeholder="{{searchPlaceHolder}}">
 	<input class="d-hidden"
 		attach-point="valueNode"
 		readonly name="{{name}}" value="{{value}}">

--- a/tests/unit/Combobox.js
+++ b/tests/unit/Combobox.js
@@ -203,6 +203,7 @@ define([
 		assert.strictEqual(combo.baseClass, outerCSS, "combo.baseClass");
 		assert.strictEqual(combo.filterMode, "startsWith", "combo.filterMode");
 		assert.isTrue(combo.ignoreCase, "combo.ignoreCase");
+		assert.strictEqual(combo.inputNode.placeholder, "Search", combo.inputNode.placeholder);
 	};
 
 	var CommonTestCases = {


### PR DESCRIPTION
Add check within a unit test.
Fixes #683.