### PR TITLE
Restore down-arrow key original behaviour, even if the inputNode is empty,

### DIFF
--- a/Combobox.js
+++ b/Combobox.js
@@ -268,7 +268,7 @@ define([
 		source: null,
 
 		/**
-		 * Minimum number of characters before a filter operation runs.
+		 * Minimum number of characters before the dropdown automatically openss.
 		 * However, aside the above, depending of its value, the widget behavior changes slightly.
 		 * In fact:
 		 * - if minFilterChars = 0
@@ -287,7 +287,6 @@ define([
 		 * @type {string}
 		 */
 		displayedValue: "",
-
 
 		/**
 		 * It's `true` if the dropdown should be centered, and returns
@@ -520,11 +519,6 @@ define([
 								// deferred such that the user can see the selection feedback
 								// before the dropdown closes.
 								this.closeDropDown(true/*refocus*/);
-
-								// Re-initialize the query, only if we are not in auto-complete mode.
-								if (!this.hasDownArrow) {
-									this.list.query = this._getDefaultQuery();
-								}
 							}.bind(this), 100); // worth exposing a property for the delay?
 						}
 					}
@@ -623,41 +617,26 @@ define([
 		},
 
 		/**
-		 * Establishes if the query has to run or not, depending of different factors, among
-		 * - mobile version or not
-		 * - hasDownArrown (auto-complete mode)
-		 * - numbers of characters typed into the inputNode element.
-		 * @param  {HTMLElement} inputElement the input element containing chars typed by the user.
-		 * @return {boolean}
+		 * Toggles the popup's visibility.
+		 * If in mobile, toggles list visibility.
+		 * If in desktop, closes or opens the popup.
 		 */
-		shouldRunQuery: function (inputElement) {
-			if (inputElement.value.length !== 0) {
-				// inputNode contains text
-				if (inputElement.value.length < this.minFilterChars) {
-					if (!this._isMobile) {
-						this.closeDropDown();
-					}
-					return false;
-				}
-			} else {
-				// inputNode does not contain text
-				if (!this.hasDownArrow) {
-					// in auto complete mode
-					this.closeDropDown();
-					this._toggleComboPopupList();
-					return false;
-				}
-			}
-			return true;
-		},
-
-		/**
-		 * Toggles the list's visibility when ComboPopup is used (so in mobile)
-		 */
-		_toggleComboPopupList: function () {
+		_togglePopupList: function (inputElement) {
+			var showList = inputElement.value.length >= this.minFilterChars;
 			if (this._isMobile) {
-				this.list.setAttribute("d-shown", "" + this.inputNode.value.length >= this.minFilterChars);
+				// Mobile version.
+				if (showList) {
+					this.filter(inputElement.value);
+				}
+				this.list.setAttribute("d-shown", "" + showList);
 				this.list.emit("delite-size-change");
+			} else {
+				// Desktop version.
+				if (showList) {
+					this.openDropDown();
+				} else {
+					this.closeDropDown(true /*refocus*/);
+				}
 			}
 		},
 
@@ -689,9 +668,7 @@ define([
 					delete this._timeoutHandle;
 				}
 				this._timeoutHandle = this.defer(function () {
-					if (this.shouldRunQuery(inputElement)) {
-						this.filter(inputElement.value);
-					}
+					this._togglePopupList(inputElement);
 				}.bind(this), this.filterDelay);
 
 				// Stop the spurious "input" events emitted while the user types
@@ -822,26 +799,28 @@ define([
 		 * @protected
 		 */
 		filter: function (inputText) {
-			// Escape special chars in search string, see
-			// http://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex.
-			var filterTxt = inputText.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
-			if (this.filterMode === "startsWith") {
-				filterTxt = "^" + filterTxt;
-			} else if (this.filterMode === "is") {
-				filterTxt = "^" + filterTxt + "$";
-			} // nothing to add for "contains"
+			if (!this.autoFilter || inputText.length === 0) {
+				this.list.query = this._getDefaultQuery();
+			} else {
+				// Escape special chars in search string, see
+				// http://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex.
+				var filterTxt = inputText.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+				if (this.filterMode === "startsWith") {
+					filterTxt = "^" + filterTxt;
+				} else if (this.filterMode === "is") {
+					filterTxt = "^" + filterTxt + "$";
+				} // nothing to add for "contains"
 
-			var rexExp = new RegExp(filterTxt, this.ignoreCase ? "i" : "");
-			this.list.query = this.getQuery({
-				rexExp: rexExp,
-				inputText: inputText
-			});
+				var rexExp = new RegExp(filterTxt, this.ignoreCase ? "i" : "");
+				this.list.query = this.getQuery({
+					rexExp: rexExp,
+					inputText: inputText
+				});
+			}
+
 			if (this.source) {
 				this.list.source = this.source;
 			}
-
-			// Open popup in order to show the list's content (loading panel, no-items element or items).
-			this.openDropDown();
 		},
 
 		/**
@@ -889,15 +868,11 @@ define([
 
 		openDropDown: dcl.superCall(function (sup) {
 			return function () {
-				// Assign widget's source to the list's source.
-				if (this.source) {
-					this.list.source = this.source;
-				}
+				this.filter(this.inputNode.value);
 
 				this._setSelectedItems();
 
 				if (!this.opened) {
-
 					// On desktop, leave focus in the original <input>.  But on mobile, focus the popup dialog.
 					this.focusOnPointerOpen = this.focusOnKeyboardOpen = this._isMobile;
 
@@ -921,9 +896,8 @@ define([
 						this._updateScroll(undefined, true);	// sets this.list.navigatedDescendant
 						this._setActiveDescendant(this.list.navigatedDescendant);
 					} else {
-						// mobile version
-						if (!this.hasDownArrow) {
-							this._toggleComboPopupList();
+						if (this.hasDownArrow) {
+							this.dropDown.inputNode.value = this.inputNode.value;
 						}
 						this.dropDown.focus();
 					}
@@ -949,17 +923,11 @@ define([
 		}),
 
 		// HasDropDown#_dropDownKeyUpHandler() override.
-		// Do not call openDropDown if widget does not have a down arrow shown.
-		// This means the widget is configured in auto-complete mode.
+		// Do not call openDropDown if widget does not have a down arrow shown (auto-complete mode).
 		// In this mode the popup will open when the user typed something and text.length > this.minFilterChars.
 		_dropDownKeyUpHandler: dcl.superCall(function (sup) {
 			return function () {
 				if (this.hasDownArrow) {
-					if (this.inputNode.value.length === 0 && this.minFilterChars === 0) {
-						this.list.query = this._getDefaultQuery();
-					} else if (this.inputNode.value.length < this.minFilterChars) {
-						return;
-					}
 					sup.call(this);
 				}
 			};

--- a/tests/functional/ComboPopup.html
+++ b/tests/functional/ComboPopup.html
@@ -93,6 +93,19 @@
 
 				var activeDescendantNode = document.getElementById(
 						combo.inputNode.getAttribute("aria-activedescendant"));
+
+				// Store ids for item cells such that the automatic functional test
+				// can retrieve them.
+				var itemRenderers = combo.list.getItemRenderers();
+				var i;
+				for (i = 0; i < itemRenderers.length; i++) {
+					itemRenderers[i].renderNode.id = combo.id + "_item" + i;
+				}
+				var categoryRenderers = combo.list.querySelectorAll("." + combo.list._cssClasses.category);
+				for (i = 0; i < categoryRenderers.length; i++) {
+					categoryRenderers.item(i).renderNode.id = combo.id + "_category" + i;
+				}
+
 				return {
 					inputNodeValue: combo.inputNode.value,
 					widgetValue: combo.value,

--- a/tests/functional/ComboPopup.js
+++ b/tests/functional/ComboPopup.js
@@ -107,7 +107,7 @@ define([
 						valueNodeValue: "France",
 						opened: true,
 						selectedItemsCount: 1,
-						itemRenderersCount: 37,
+						itemRenderersCount: 1, // a filter did run, filtering only `France`
 						inputEventCounter: 0,
 						changeEventCounter: 0,
 						widgetValueAtLatestInputEvent: undefined, // never received
@@ -117,6 +117,13 @@ define([
 					}, "after click on root node");
 			})
 			.findByCssSelector(".d-combo-popup .d-linear-layout .d-combobox-input[d-hidden='false']")
+			.pressKeys(keys.BACKSPACE)
+			.pressKeys(keys.BACKSPACE)
+			.pressKeys(keys.BACKSPACE)
+			.pressKeys(keys.BACKSPACE)
+			.pressKeys(keys.BACKSPACE)
+			.pressKeys(keys.BACKSPACE)
+			// removed France
 			.type("j")
 			.type("a")
 			.type("p")
@@ -132,7 +139,7 @@ define([
 						opened: true,
 						selectedItemsCount: 0,
 						itemRenderersCount: 30,
-						inputEventCounter: 3, // typed "jap"
+						inputEventCounter: 9, // delted France and typed "jap"
 						changeEventCounter: 0,
 						widgetValueAtLatestInputEvent: "jap",
 						valueNodeValueAtLatestInputEvent: "jap",
@@ -156,7 +163,7 @@ define([
 						valueNodeValue: "",
 						opened: true,
 						selectedItemsCount: 0,
-						itemRenderersCount: 37,
+						itemRenderersCount: 30,
 						inputEventCounter: 3,
 						changeEventCounter: 0,
 						widgetValueAtLatestInputEvent: "",
@@ -209,10 +216,10 @@ define([
 					label = null;
 				})
 			.end()
-			.findByXpath("//d-combo-popup//d-list//div//d-list-item-renderer[7]")
+			.findByXpath("//d-combo-popup//d-list//div//d-list-item-renderer[1]")
 				.getVisibleText()
 				.then(function (value) {
-					assert(/^China/.test(value), "item rendender #8 : " + value);
+					assert(/^France/.test(value), "item rendender #8 : " + value);
 				})
 			.end()
 			.findByCssSelector(".d-combo-popup .d-linear-layout .d-combobox-input[d-hidden='" + !hasFilterInput + "']")

--- a/tests/functional/Combobox-decl.html
+++ b/tests/functional/Combobox-decl.html
@@ -121,8 +121,21 @@
 				combo._inputEventCounter = 0;
 				combo._changeEventCounter = 0;
 
+				// Store ids for item cells such that the automatic functional test
+				// can retrieve them.
+
 				var activeDescendantNode = document.getElementById(
 						combo.inputNode.getAttribute("aria-activedescendant"));
+
+				var itemRenderers = combo.list.getItemRenderers();
+				var i;
+				for (i = 0; i < itemRenderers.length; i++) {
+					itemRenderers[i].renderNode.id = combo.id + "_item" + i;
+				}
+				var categoryRenderers = combo.list.querySelectorAll("." + combo.list._cssClasses.category);
+				for (i = 0; i < categoryRenderers.length; i++) {
+					categoryRenderers.item(i).renderNode.id = combo.id + "_category" + i;
+				}
 				return {
 					inputNodeValue: combo.inputNode.value,
 					widgetValue: combo.value,

--- a/tests/functional/Combobox.js
+++ b/tests/functional/Combobox.js
@@ -74,7 +74,7 @@ define([
 	};
 
 	// Check the state of the widget after selecting options using the keyboard.
-	var checkKeyboardNavigationSingleSelection = function (remote, comboId, autoFilter) {
+	var checkKeyboardNavigationSingleSelectionAutoFilterFalse = function (remote, comboId) {
 		// Expression executed in the browser for collecting data allowing to
 		// check the state of the widget. The function getComboState() is defined in
 		// the loaded HTML file. Note that each call of getComboState() resets the
@@ -210,128 +210,169 @@ define([
 						valueNodeValueAtLatestChangeEvent: "Germany"
 					}, "after ESCAPE");
 			});
+		return res;
+	};
 
-		// Additional tests for autoFilter=true
-		if (autoFilter) {
-			res = res
+	var checkKeyboardNavigationSingleSelectionAutoFilterTrue = function (remote, comboId) {
+		// Expression executed in the browser for collecting data allowing to
+		// check the state of the widget. The function getComboState() is defined in
+		// the loaded HTML file. Note that each call of getComboState() resets the
+		// event counters (inputEventCounter and changeEventCounter).
+		var executeExpr = "return getComboState(\"" + comboId + "\");";
+		var res = loadFile(remote, "./Combobox-decl.html")
+			.execute(comboId + ".focus();  " + executeExpr)
+			.then(function (comboState) {
+				// No selection by default
+				checkComboState(comboId, comboState,
+					{ // expected combo state
+						inputNodeValue: "France",
+						widgetValue: "France",
+						valueNodeValue: "France",
+						opened: false,
+						selectedItemsCount: 0,
+						itemRenderersCount: 37,
+						inputEventCounter: 0, // no event so far
+						changeEventCounter: 0,
+						widgetValueAtLatestInputEvent: undefined, // never received
+						valueNodeValueAtLatestInputEvent: undefined,
+						widgetValueAtLatestChangeEvent: undefined,
+						valueNodeValueAtLatestChangeEvent: undefined
+					}, "after initial focus");
+			})
+			.pressKeys(keys.ARROW_DOWN) // popup should open.
+			.sleep(750)
+			.execute(executeExpr)
+			.then(function (comboState) {
+				// the first ARROW_DOWN only opens the dropdown.
+				checkComboState(comboId, comboState,
+					{ // expected combo state
+						inputNodeValue: "France",
+						widgetValue: "France",
+						valueNodeValue: "France",
+						opened: true,
+						selectedItemsCount: 1,
+						itemRenderersCount: 1, // filtered by "France"
+						inputEventCounter: 0, // no new event
+						changeEventCounter: 0,
+						widgetValueAtLatestInputEvent: undefined, // never received
+						valueNodeValueAtLatestInputEvent: undefined,
+						widgetValueAtLatestChangeEvent: undefined,
+						valueNodeValueAtLatestChangeEvent: undefined
+					}, "after first ARROW_DOWN");
+				assert(/^France/.test(comboState.activeDescendant),
+					"activeDescendant after first ARROW_DOWN: " + comboState.activeDescendant);
+			})
+			.pressKeys(keys.BACKSPACE) // "Franc"
+			.pressKeys(keys.BACKSPACE) // "Fran"
+			.pressKeys(keys.BACKSPACE) // "Fra"
+			.pressKeys(keys.BACKSPACE) // "Fr"
+			.pressKeys(keys.BACKSPACE) // "F"
+			.pressKeys(keys.BACKSPACE) // "" - At this stage the popup should be closed.
+			.execute(executeExpr)
+			.then(function (comboState) {
+				checkComboState(comboId, comboState,
+					{ // expected combo state
+						inputNodeValue: "",
+						widgetValue: "",
+						valueNodeValue: "",
+						opened: false,
+						selectedItemsCount: 0,
+						itemRenderersCount: 1,
+						inputEventCounter: 6,
+						changeEventCounter: 1, // popup got closed.
+						widgetValueAtLatestInputEvent: "",
+						valueNodeValueAtLatestInputEvent: "",
+						widgetValueAtLatestChangeEvent: "",
+						valueNodeValueAtLatestChangeEvent: ""
+					}, "after deleted `France`");
+			})
+			.pressKeys("u") // filters all countries but UK and USA
+			.execute(executeExpr)
+			.then(function (comboState) {
+				// Reopens the dropdown. No other state change, except the
+				// input node now showing just the "u" character, and the list now
+				// has only 2 item renderers (UK and USA).
+				checkComboState(comboId, comboState,
+					{ // expected combo state
+						inputNodeValue: "u",
+						widgetValue: "u",
+						valueNodeValue: "u",
+						opened: true,
+						selectedItemsCount: 0,
+						itemRenderersCount: 2,
+						inputEventCounter: 1,
+						changeEventCounter: 0, // no commit yet.
+						widgetValueAtLatestInputEvent: "u",
+						valueNodeValueAtLatestInputEvent: "u",
+						widgetValueAtLatestChangeEvent: "",
+						valueNodeValueAtLatestChangeEvent: ""
+					}, "after filter starting with u character");
+			})
+			.pressKeys(keys.SPACE) // now filtering string is "u " which doesn't match any country
+			.execute(executeExpr)
+			.then(function (comboState) {
+				// Just reopens the dropdown. No other state change, except the
+				// input node now showing just the "u" character, and the list now
+				// has only 2 item renderers (UK and USA).
+				checkComboState(comboId, comboState,
+					{ // expected combo state
+						inputNodeValue: "u ",
+						widgetValue: "u ",
+						valueNodeValue: "u ",
+						opened: true,
+						selectedItemsCount: 0,
+						itemRenderersCount: 0,
+						inputEventCounter: 1,
+						changeEventCounter: 0, // unchanged
+						widgetValueAtLatestInputEvent: "u ",
+						valueNodeValueAtLatestInputEvent: "u ",
+						widgetValueAtLatestChangeEvent: "",
+						valueNodeValueAtLatestChangeEvent: ""
+					}, "after filter starting with u plus SPACE character");
+			})
+			.pressKeys(keys.BACKSPACE) // delete the SPACE, back to "u" filter
 			.pressKeys(keys.ARROW_DOWN)
-				.execute(executeExpr)
-				.then(function (comboState) {
-					// Just reopens the dropdown. No other state change.
-					checkComboState(comboId, comboState,
-						{ // expected combo state
-							inputNodeValue: "Germany",
-							widgetValue: "Germany",
-							valueNodeValue: "Germany",
-							opened: true,
-							selectedItemsCount: 1,
-							itemRenderersCount: 37,
-							inputEventCounter: 0, // unchanged
-							changeEventCounter: 0,
-							widgetValueAtLatestInputEvent: "Germany",
-							valueNodeValueAtLatestInputEvent: "Germany",
-							widgetValueAtLatestChangeEvent: "Germany",
-							valueNodeValueAtLatestChangeEvent: "Germany"
-						}, "after ARROW_DOWN following ESCAPE");
-					assert(/^Germany/.test(comboState.activeDescendant),
-						"activeDescendant after after ARROW_DOWN following ESCAPE: " + comboState.activeDescendant);
-				})
-				.pressKeys(keys.BACKSPACE) // Delete the 7 chars of "Germany"
-				.pressKeys(keys.BACKSPACE)
-				.pressKeys(keys.BACKSPACE)
-				.pressKeys(keys.BACKSPACE)
-				.pressKeys(keys.BACKSPACE)
-				.pressKeys(keys.BACKSPACE)
-				.pressKeys(keys.BACKSPACE)
-				.pressKeys("u") // filters all countries but UK and USA
-				.execute(executeExpr)
-				.then(function (comboState) {
-					// Reopens the dropdown. No other state change, except the
-					// input node now showing just the "u" character, and the list now
-					// has only 2 item renderers (UK and USA).
-					checkComboState(comboId, comboState,
-						{ // expected combo state
-							inputNodeValue: "u",
-							widgetValue: "u",
-							valueNodeValue: "u",
-							opened: true,
-							selectedItemsCount: 0,
-							itemRenderersCount: 2,
-							inputEventCounter: 8,
-							changeEventCounter: 0, // no commit yet.
-							widgetValueAtLatestInputEvent: "u",
-							valueNodeValueAtLatestInputEvent: "u",
-							widgetValueAtLatestChangeEvent: "Germany",
-							valueNodeValueAtLatestChangeEvent: "Germany"
-						}, "after filter starting with u character");
-				})
-				.pressKeys(keys.SPACE) // now filtering string is "u " which doesn't match any country
-				.execute(executeExpr)
-				.then(function (comboState) {
-					// Just reopens the dropdown. No other state change, except the
-					// input node now showing just the "u" character, and the list now
-					// has only 2 item renderers (UK and USA).
-					checkComboState(comboId, comboState,
-						{ // expected combo state
-							inputNodeValue: "u ",
-							widgetValue: "u ",
-							valueNodeValue: "u ",
-							opened: true,
-							selectedItemsCount: 0,
-							itemRenderersCount: 0,
-							inputEventCounter: 1, // incremented
-							changeEventCounter: 0, // unchanged
-							widgetValueAtLatestInputEvent: "u ",
-							valueNodeValueAtLatestInputEvent: "u ",
-							widgetValueAtLatestChangeEvent: "Germany",
-							valueNodeValueAtLatestChangeEvent: "Germany"
-						}, "after filter starting with u plus SPACE character");
-				})
-				.pressKeys(keys.BACKSPACE) // delete the SPACE, back to "u" filter
-				.pressKeys(keys.ARROW_DOWN)
-				.execute(executeExpr)
-				.then(function (comboState) {
-					// Now again just UK and USA are rendered.
-					checkComboState(comboId, comboState,
-						{ // expected combo state
-							inputNodeValue: "UK",
-							widgetValue: "UK",
-							valueNodeValue: "UK",
-							opened: true,
-							selectedItemsCount: 1,
-							itemRenderersCount: 2, // UK and USA
-							inputEventCounter: 2, // incremented
-							changeEventCounter: 0, // unchanged
-							widgetValueAtLatestInputEvent: "UK",
-							valueNodeValueAtLatestInputEvent: "UK",
-							widgetValueAtLatestChangeEvent: "Germany",
-							valueNodeValueAtLatestChangeEvent: "Germany"
-						}, "after ARROW_DOWN with filtered list");
-					assert(/^UK/.test(comboState.activeDescendant),
-						"activeDescendant after ARROW_DOWN with filtered list: " + comboState.activeDescendant);
-				})
-				.pressKeys(keys.ENTER) // closes the popup and validates the changes
-				.sleep(500) // wait for async closing
-				.execute(executeExpr)
-				.then(function (comboState) {
-					checkComboState(comboId, comboState,
-						{ // expected combo state
-							inputNodeValue: "UK",
-							widgetValue: "UK",
-							valueNodeValue: "UK",
-							opened: false,
-							selectedItemsCount: 1,
-							itemRenderersCount: 2, // UK and USA. The query was not reset yet.
-							inputEventCounter: 0, // unchanged
-							changeEventCounter: 1, // incremented
-							widgetValueAtLatestInputEvent: "UK",
-							valueNodeValueAtLatestInputEvent: "UK",
-							widgetValueAtLatestChangeEvent: "UK",
-							valueNodeValueAtLatestChangeEvent: "UK"
-						}, "after closing with ENTER the filtered list");
-				});
-		}
-
+			.execute(executeExpr)
+			.then(function (comboState) {
+				// Now again just UK and USA are rendered.
+				checkComboState(comboId, comboState,
+					{ // expected combo state
+						inputNodeValue: "UK",
+						widgetValue: "UK",
+						valueNodeValue: "UK",
+						opened: true,
+						selectedItemsCount: 1,
+						itemRenderersCount: 2, // UK and USA visible
+						inputEventCounter: 2, // incremented
+						changeEventCounter: 0, // unchanged
+						widgetValueAtLatestInputEvent: "UK",
+						valueNodeValueAtLatestInputEvent: "UK",
+						widgetValueAtLatestChangeEvent: "",
+						valueNodeValueAtLatestChangeEvent: ""
+					}, "after ARROW_DOWN with filtered list");
+				assert(/^UK/.test(comboState.activeDescendant),
+					"activeDescendant after ARROW_DOWN with filtered list: " + comboState.activeDescendant);
+			})
+			.pressKeys(keys.ENTER) // closes the popup and validates the changes
+			.sleep(500) // wait for async closing
+			.execute(executeExpr)
+			.then(function (comboState) {
+				checkComboState(comboId, comboState,
+					{ // expected combo state
+						inputNodeValue: "UK",
+						widgetValue: "UK",
+						valueNodeValue: "UK",
+						opened: false,
+						selectedItemsCount: 1,
+						itemRenderersCount: 2, // UK and USA. The query was not reset yet.
+						inputEventCounter: 0, // unchanged
+						changeEventCounter: 1, // incremented
+						widgetValueAtLatestInputEvent: "UK",
+						valueNodeValueAtLatestInputEvent: "UK",
+						widgetValueAtLatestChangeEvent: "UK",
+						valueNodeValueAtLatestChangeEvent: "UK"
+					}, "after closing with ENTER the filtered list");
+			});
 		return res;
 	};
 
@@ -928,7 +969,7 @@ define([
 						valueNodeValue: "France",
 						opened: true,
 						selectedItemsCount: 1,
-						itemRenderersCount: 37,
+						itemRenderersCount: 1,
 						inputEventCounter: 0, // unchanged
 						changeEventCounter: 0,
 						widgetValueAtLatestInputEvent: undefined,
@@ -1156,7 +1197,7 @@ define([
 			if (remote.environmentType.brokenSendKeys || !remote.environmentType.nativeEvents) {
 				return this.skip("no keyboard support");
 			}
-			return checkKeyboardNavigationSingleSelection(remote, "combo1", false);
+			return checkKeyboardNavigationSingleSelectionAutoFilterFalse(remote, "combo1");
 		},
 
 		"keyboard navigation selectionMode=single, autoFilter=true": function () {
@@ -1164,7 +1205,7 @@ define([
 			if (remote.environmentType.brokenSendKeys || !remote.environmentType.nativeEvents) {
 				return this.skip("no keyboard support");
 			}
-			return checkKeyboardNavigationSingleSelection(remote, "combo2", true);
+			return checkKeyboardNavigationSingleSelectionAutoFilterTrue(remote, "combo2");
 		},
 
 		"keyboard navigation selectionMode = multiple": function () {


### PR DESCRIPTION
Restore down-arrow key original behaviour, even if the inputNode is empty. This means that if you press down arrow key, the popup will open - (Fixes accessibility issues).
Refs #668.