### PR TITLE
Combobox compatible with Aria 1.1.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Combobox.js
+++ b/Combobox.js
@@ -459,14 +459,6 @@ define([
 			}
 		},
 
-		setAttribute: HTMLElement.prototype.setAttribute,
-
-		getAttribute: HTMLElement.prototype.getAttribute,
-
-		hasAttribute: HTMLElement.prototype.hasAttribute,
-
-		removeAttribute: HTMLElement.prototype.removeAttribute,
-
 		/**
 		 * Configures inputNode such that the text is selectable or unselectable.
 		 * @private
@@ -949,7 +941,7 @@ define([
 
 				return promise.then(function () {
 					this.setAttribute("aria-owns", this.dropDown.id);
-					this.popupStateNode.setAttribute("aria-controls", this.dropDown.id);
+					this.inputNode.setAttribute("aria-controls", this.dropDown.id);
 
 					// Avoid that List gives focus to list items when navigating, which would
 					// blur the input field used for entering the filtering criteria.
@@ -974,7 +966,7 @@ define([
 				input.removeAttribute("aria-activedescendant");
 
 				this.removeAttribute("aria-owns");
-				this.popupStateNode.removeAttribute("aria-controls");
+				this.inputNode.removeAttribute("aria-controls");
 
 				// Closing the dropdown represents a commit interaction, unless the dropdown closes
 				// automatically because the user backspaced, in which case suppressChangeEvent is true.
@@ -1034,7 +1026,8 @@ define([
 					nd.id = "d-combobox-item-" + idCounter++;
 				}
 
-				this.setAttribute("aria-activedescendant", nd.id);
+				var input = this._popupInput || this.inputNode;
+ -				input.setAttribute("aria-activedescendant", nd.id);
 			}
 		}
 	});

--- a/Combobox.js
+++ b/Combobox.js
@@ -459,21 +459,13 @@ define([
 			}
 		},
 
-		setAttribute: function () {
-			HTMLElement.prototype.setAttribute.apply(this, arguments);
-		},
+		setAttribute: HTMLElement.prototype.setAttribute,
 
-		getAttribute: function () {
-			HTMLElement.prototype.getAttribute.apply(this, arguments);
-		},
+		getAttribute: HTMLElement.prototype.getAttribute,
 
-		hasAttribute: function () {
-			HTMLElement.prototype.hasAttribute.apply(this, arguments);
-		},
+		hasAttribute: HTMLElement.prototype.hasAttribute,
 
-		removeAttribute: function () {
-			HTMLElement.prototype.removeAttribute.apply(this, arguments);
-		},
+		removeAttribute: HTMLElement.prototype.removeAttribute,
 
 		/**
 		 * Configures inputNode such that the text is selectable or unselectable.

--- a/Combobox.js
+++ b/Combobox.js
@@ -1027,7 +1027,7 @@ define([
 				}
 
 				var input = this._popupInput || this.inputNode;
- -				input.setAttribute("aria-activedescendant", nd.id);
+				input.setAttribute("aria-activedescendant", nd.id);
 			}
 		}
 	});

--- a/Combobox.js
+++ b/Combobox.js
@@ -940,7 +940,6 @@ define([
 				var promise = sup.apply(this, arguments);
 
 				return promise.then(function () {
-					this.setAttribute("aria-owns", this.dropDown.id);
 					this.inputNode.setAttribute("aria-controls", this.dropDown.id);
 
 					// Avoid that List gives focus to list items when navigating, which would
@@ -965,7 +964,6 @@ define([
 				var input = this._popupInput || this.inputNode;
 				input.removeAttribute("aria-activedescendant");
 
-				this.removeAttribute("aria-owns");
 				this.inputNode.removeAttribute("aria-controls");
 
 				// Closing the dropdown represents a commit interaction, unless the dropdown closes

--- a/Combobox.js
+++ b/Combobox.js
@@ -297,6 +297,13 @@ define([
 		 */
 		_isMobile: !!ComboPopup,
 
+		/**
+		 * The Combobox widget is a special component where we don't need to move the
+		 * aria attributes from the root element to the focusNode. So here we're
+		 * overriding this property to false, disabling the move procedure.
+		 */
+		moveAriaAttributes: false,
+
 		createdCallback: function () {
 			// Declarative case.
 			var list = this.querySelector("d-list");
@@ -450,6 +457,22 @@ define([
 					this._popupInput.value = this.displayedValue;
 				}
 			}
+		},
+
+		setAttribute: function () {
+			HTMLElement.prototype.setAttribute.apply(this, arguments);
+		},
+
+		getAttribute: function () {
+			HTMLElement.prototype.getAttribute.apply(this, arguments);
+		},
+
+		hasAttribute: function () {
+			HTMLElement.prototype.hasAttribute.apply(this, arguments);
+		},
+
+		removeAttribute: function () {
+			HTMLElement.prototype.removeAttribute.apply(this, arguments);
 		},
 
 		/**
@@ -933,6 +956,9 @@ define([
 				var promise = sup.apply(this, arguments);
 
 				return promise.then(function () {
+					this.setAttribute("aria-owns", this.dropDown.id);
+					this.popupStateNode.setAttribute("aria-controls", this.dropDown.id);
+
 					// Avoid that List gives focus to list items when navigating, which would
 					// blur the input field used for entering the filtering criteria.
 					this.dropDown.focusDescendants = false;
@@ -954,6 +980,9 @@ define([
 			return function (focus, suppressChangeEvent) {
 				var input = this._popupInput || this.inputNode;
 				input.removeAttribute("aria-activedescendant");
+
+				this.removeAttribute("aria-owns");
+				this.popupStateNode.removeAttribute("aria-controls");
 
 				// Closing the dropdown represents a commit interaction, unless the dropdown closes
 				// automatically because the user backspaced, in which case suppressChangeEvent is true.
@@ -1013,8 +1042,7 @@ define([
 					nd.id = "d-combobox-item-" + idCounter++;
 				}
 
-				var input = this._popupInput || this.inputNode;
-				input.setAttribute("aria-activedescendant", nd.id);
+				this.setAttribute("aria-activedescendant", nd.id);
 			}
 		}
 	});

--- a/Combobox.js
+++ b/Combobox.js
@@ -961,9 +961,7 @@ define([
 
 		closeDropDown: dcl.superCall(function (sup) {
 			return function (focus, suppressChangeEvent) {
-				var input = this._popupInput || this.inputNode;
-				input.removeAttribute("aria-activedescendant");
-
+				this.popupStateNode.removeAttribute("aria-activedescendant");
 				this.inputNode.removeAttribute("aria-controls");
 
 				// Closing the dropdown represents a commit interaction, unless the dropdown closes
@@ -1024,8 +1022,7 @@ define([
 					nd.id = "d-combobox-item-" + idCounter++;
 				}
 
-				var input = this._popupInput || this.inputNode;
-				input.setAttribute("aria-activedescendant", nd.id);
+				this.popupStateNode.setAttribute("aria-activedescendant", nd.id);
 			}
 		}
 	});

--- a/Combobox/ComboPopup.html
+++ b/Combobox/ComboPopup.html
@@ -1,15 +1,15 @@
-<template role="presentation"
-	requires="deliteful/LinearLayout, deliteful/Button">
+<template requires="deliteful/LinearLayout, deliteful/Button" 
+	role="combobox" aria-expanded="true" aria-owns="{{combobox.list.id}}" aria-haspopup="listbox">
 	<d-linear-layout style="height: 100%">
 		<label class="d-combo-popup-header" for="{{widgetId}}-input">{{header}}</label>
 		<input id="{{widgetId}}-input"
 			d-hidden="{{!(this.combobox.autoFilter && this.combobox.selectionMode !== 'multiple')}}"
 			attach-point="inputNode"
 			class="d-combobox-input"
-			role="combobox" autocomplete="off" autocapitalize="none" autocorrect="off"
-			aria-autocomplete="list"
-			aria-haspopup="true"
-			aria-owns="{{combobox.list.id}}"
+			autocomplete="off" autocapitalize="none" autocorrect="off"
+			aria-autocomplete="list" 
+			aria-controls="{{combobox.list.id}}" 
+			aria-activedescendant="selected_option"
 			type="text"
 			placeholder="{{combobox.searchPlaceHolder}}">
 		<div attach-point="listNode"></div>

--- a/Combobox/ComboPopup.html
+++ b/Combobox/ComboPopup.html
@@ -8,8 +8,7 @@
 			class="d-combobox-input"
 			autocomplete="off" autocapitalize="none" autocorrect="off"
 			aria-autocomplete="list" 
-			aria-controls="{{combobox.list.id}}" 
-			aria-activedescendant="selected_option"
+			aria-controls="{{combobox.list.id}}"
 			type="text"
 			placeholder="{{combobox.searchPlaceHolder}}">
 		<div attach-point="listNode"></div>

--- a/Combobox/Combobox.html
+++ b/Combobox/Combobox.html
@@ -1,6 +1,5 @@
-<template class="d-combobox" role="presentation">
+<template class="d-combobox" role="combobox" aria-expanded="{{this.opened}}" attach-point="popupNode">
 	<input class="d-combobox-input"
-		role="combobox"
 		attach-point="inputNode,focusNode"
 		autocomplete="off" autocorrect="off" autocapitalize="none"
 		aria-autocomplete="list"

--- a/Combobox/Combobox.html
+++ b/Combobox/Combobox.html
@@ -1,4 +1,4 @@
-<template class="d-combobox" role="combobox" aria-expanded="{{this.opened}}" attach-point="popupNode">
+<template class="d-combobox" role="combobox" aria-expanded="{{opened}}" attach-point="popupStateNode">
 	<input class="d-combobox-input"
 		attach-point="inputNode,focusNode"
 		autocomplete="off" autocorrect="off" autocapitalize="none"

--- a/tests/functional/ComboPopup.js
+++ b/tests/functional/ComboPopup.js
@@ -189,7 +189,7 @@ define([
 					}).end();
 			}).end()
 
-			.findByCssSelector("#" + comboId + "_dropdown input").getAttribute("aria-owns").then(function (listId) {
+			.findByCssSelector("#" + comboId + "_dropdown input").getAttribute("aria-controls").then(function (listId) {
 				// Use aria-owns attribute to find the <d-list>, and then spot check that the <d-list>
 				// contents are correct.
 				return remote.findByCssSelector("#" + listId + " d-list-item-renderer:nth-child(2)")

--- a/tests/functional/Combobox-decl.html
+++ b/tests/functional/Combobox-decl.html
@@ -127,7 +127,7 @@
 				// can retrieve them.
 
 				var activeDescendantNode = document.getElementById(
-						combo.inputNode.getAttribute("aria-activedescendant"));
+						combo.popupStateNode.getAttribute("aria-activedescendant"));
 
 				var itemRenderers = combo.list.getItemRenderers();
 				var i;


### PR DESCRIPTION
- Depends on https://github.com/ibm-js/delite/pull/483
- Disable the move procedure of aria attributes to the focusNode.
- Make setAttribute, getAttribute, hasAttribute and removeAttribute use the HTMLElement.prototype method.
- _setActiveDescendant should set the attribute on the root node accordingly to the spec.