### PR TITLE
Moving the active-descendent attribute to inputNode

### DIFF
--- a/Combobox.js
+++ b/Combobox.js
@@ -940,7 +940,7 @@ define([
 
 		closeDropDown: dcl.superCall(function (sup) {
 			return function (focus, suppressChangeEvent) {
-				this.popupStateNode.removeAttribute("aria-activedescendant");
+				this.inputNode.removeAttribute("aria-activedescendant");
 				this.inputNode.removeAttribute("aria-controls");
 
 				// Closing the dropdown represents a commit interaction, unless the dropdown closes
@@ -1001,7 +1001,7 @@ define([
 					nd.id = "d-combobox-item-" + idCounter++;
 				}
 
-				this.popupStateNode.setAttribute("aria-activedescendant", nd.id);
+				this.inputNode.setAttribute("aria-activedescendant", nd.id);
 			}
 		},
 

--- a/tests/functional/Combobox-decl.html
+++ b/tests/functional/Combobox-decl.html
@@ -127,7 +127,7 @@
 				// can retrieve them.
 
 				var activeDescendantNode = document.getElementById(
-						combo.popupStateNode.getAttribute("aria-activedescendant"));
+						combo.inputNode.getAttribute("aria-activedescendant"));
 
 				var itemRenderers = combo.list.getItemRenderers();
 				var i;


### PR DESCRIPTION
I guess during the migration to aria 1.1 I did a mistake about which node should receive the attribute.