### PR TITLE
Removed attributes that prevents the user to focus the buttons

### DIFF
--- a/Combobox/ComboPopup.html
+++ b/Combobox/ComboPopup.html
@@ -1,21 +1,23 @@
-<template requires="deliteful/LinearLayout, deliteful/Button">
+<template requires="deliteful/LinearLayout, deliteful/Button" role="dialog" aria-labelledby="{{widgetId}}-title">
 	<d-linear-layout style="height: 100%">
-		<label class="d-combo-popup-header" for="{{widgetId}}-input">{{header}}</label>
-		<input id="{{widgetId}}-input"
-			d-hidden="{{!(this.combobox.autoFilter && this.combobox.selectionMode !== 'multiple')}}"
-			attach-point="inputNode"
-			class="d-combobox-input"
-			autocomplete="off" autocapitalize="none" autocorrect="off"
-			aria-autocomplete="list"
-			aria-controls="{{combobox.list.id}}"
-			type="text"
-			placeholder="{{combobox.searchPlaceHolder}}">
+		<span class="d-combo-popup-header" id="{{widgetId}}-title" aria-label="{{header}}" d-shown="{{ header !== '' }}">{{header}}</span>
+		<div aria-labelledby="{{widgetId}}-title" role="combobox" aria-expanded="true" aria-owns="{{combobox.list.id}}" aria-haspopup="listbox">
+		  <input id="{{widgetId}}-input"
+				d-hidden="{{!(this.combobox.autoFilter && this.combobox.selectionMode !== 'multiple')}}"
+				attach-point="inputNode"
+				class="d-combobox-input"
+				aria-autocomplete="list" 
+				aria-controls="{{combobox.list.id}}" 
+				aria-activedescendant="{{combobox.list.navigatedDescendant}}"
+				autocomplete="off" autocapitalize="none" autocorrect="off"
+				type="text"
+				placeholder="{{combobox.searchPlaceHolder}}">
+		</div>
 		<div attach-point="listNode"></div>
-		<d-linear-layout d-hidden="{{combobox.selectionMode !== 'multiple'}}"
-			vertical="false">
-			<button is="d-button" class="fill d-combo-cancel-button"
+		<d-linear-layout d-hidden="{{combobox.selectionMode !== 'multiple'}}" vertical="false">
+			<button is="d-button" class="fill d-combo-cancel-button" tabindex="0"
 				label="{{combobox.cancelMsg}}" on-click="{{cancelHandler}}"></button>
-			<button is="d-button" class="fill d-combo-ok-button"
+			<button is="d-button" class="fill d-combo-ok-button" tabindex="0"
 				label="{{combobox.okMsg}}" on-click="{{okHandler}}"></button>
 		</d-linear-layout>
 	</d-linear-layout>

--- a/Combobox/ComboPopup.html
+++ b/Combobox/ComboPopup.html
@@ -1,6 +1,6 @@
 <template requires="deliteful/LinearLayout, deliteful/Button">
 	<d-linear-layout style="height: 100%">
-		<label class="d-combo-popup-header" for="{{widgetId}}-input" aria-label="{{header}}" d-shown="{{ header !== '' }}">{{header}}</label>
+		<label class="d-combo-popup-header" for="{{widgetId}}-input">{{header}}</label>
 		<input id="{{widgetId}}-input"
 			d-hidden="{{!(this.combobox.autoFilter && this.combobox.selectionMode !== 'multiple')}}"
 			attach-point="inputNode"

--- a/Combobox/ComboPopup.html
+++ b/Combobox/ComboPopup.html
@@ -1,7 +1,6 @@
-<template requires="deliteful/LinearLayout, deliteful/Button"
-	role="combobox" aria-expanded="true" aria-owns="{{combobox.list.id}}" aria-haspopup="listbox">
+<template requires="deliteful/LinearLayout, deliteful/Button">
 	<d-linear-layout style="height: 100%">
-		<label class="d-combo-popup-header" for="{{widgetId}}-input">{{header}}</label>
+		<label class="d-combo-popup-header" for="{{widgetId}}-input" aria-label="{{header}}" d-shown="{{ header !== '' }}">{{header}}</label>
 		<input id="{{widgetId}}-input"
 			d-hidden="{{!(this.combobox.autoFilter && this.combobox.selectionMode !== 'multiple')}}"
 			attach-point="inputNode"

--- a/tests/functional/ComboPopup.js
+++ b/tests/functional/ComboPopup.js
@@ -179,7 +179,7 @@ define([
 			// Get the ComboPopup's <input>'s id...
 			.findByCssSelector("#" + comboId + "_dropdown input").getAttribute("id").then(function (inputId) {
 				// And then get the <label> pointing to that <input>...
-				return remote.findByCssSelector("#" + comboId + "_dropdown label[for=" + inputId + "]")
+				return remote.findByCssSelector("#" + comboId + "_dropdown .d-combo-popup-header")
 					.getVisibleText().then(function (popupLabel) {
 						// And then make sure it matches the Combobox's label.
 						return remote.findByCssSelector("label[for=" + comboId + "-input]")


### PR DESCRIPTION
These attributes were "closing" the "focus context" for users using iOS + VoiceOver.
Removing the attributes open the sibling context and user is able to focus the buttons using swipe or keyboard shortcuts.

Fix #708

